### PR TITLE
use esm.sh as default CDN

### DIFF
--- a/src/livecodes/compiler/__tests__/import-map.spec.ts
+++ b/src/livecodes/compiler/__tests__/import-map.spec.ts
@@ -29,10 +29,10 @@ describe('Import map', () => {
     `;
 
     const importMap = {
-      '@codemirror/basic-setup': 'https://jspm.dev/@codemirror/basic-setup',
+      '@codemirror/basic-setup': 'https://esm.sh/@codemirror/basic-setup',
       lodash: 'https://unpkg.com/lodash',
       mylib: 'https://someurl/path/module',
-      similar2: 'https://jspm.dev/similar2',
+      similar2: 'https://esm.sh/similar2',
     };
 
     const map = createImportMap(code, config);
@@ -60,7 +60,7 @@ describe('Import map', () => {
     `;
 
     const expectedCode = `
-    import { EditorState, EditorView, basicSetup } from 'https://jspm.dev/@codemirror/basic-setup';
+    import { EditorState, EditorView, basicSetup } from 'https://esm.sh/@codemirror/basic-setup';
     import fp from "https://unpkg.com/lodash/fp.js";
     import { html } from 'http://localhost/@codemirror/lang-html';
     import { flatten } from 'https://cdn.jsdelivr.net/gh/remeda/remeda@master/src/flatten.js';

--- a/src/livecodes/services/__tests__/modulesService.spec.ts
+++ b/src/livecodes/services/__tests__/modulesService.spec.ts
@@ -4,17 +4,17 @@ describe('modulesService', () => {
   test('CDN urls', () => {
     const url = modulesService.getModuleUrl;
 
-    expect(url('uuid')).toEqual('https://jspm.dev/uuid');
+    expect(url('uuid')).toEqual('https://esm.sh/uuid');
 
-    expect(url('uuid@1.0.0')).toEqual('https://jspm.dev/uuid@1.0.0');
+    expect(url('uuid@1.0.0')).toEqual('https://esm.sh/uuid@1.0.0');
 
     expect(url('uuid@1.0.0/sub/directory/file.js')).toEqual(
-      'https://jspm.dev/uuid@1.0.0/sub/directory/file.js',
+      'https://esm.sh/uuid@1.0.0/sub/directory/file.js',
     );
 
     expect(url('jspm:uuid')).toEqual('https://jspm.dev/uuid');
 
-    expect(url('npm:uuid')).toEqual('https://jspm.dev/uuid');
+    expect(url('npm:uuid')).toEqual('https://esm.sh/uuid');
 
     expect(url('skypack:uuid')).toEqual('https://cdn.skypack.dev/uuid');
 

--- a/src/livecodes/services/modules.ts
+++ b/src/livecodes/services/modules.ts
@@ -2,14 +2,14 @@ import type { CDN } from '../models';
 
 declare const globalThis: { appCDN: CDN };
 
-const moduleCDNs: CDN[] = ['jspm', 'esm.sh', 'skypack'];
+const moduleCDNs: CDN[] = ['esm.sh', 'skypack', 'jspm'];
 const npmCDNs: CDN[] = ['unpkg', 'jsdelivr', 'fastly.jsdelivr'];
 const ghCDNs: CDN[] = ['fastly.jsdelivr.gh', 'jsdelivr.gh', 'statically'];
 
 export const modulesService = {
   getModuleUrl: (
     moduleName: string,
-    { isModule = true, defaultCDN = 'jspm' }: { isModule?: boolean; defaultCDN?: CDN } = {},
+    { isModule = true, defaultCDN = 'esm.sh' }: { isModule?: boolean; defaultCDN?: CDN } = {},
   ) => {
     moduleName = moduleName.replace(/#nobundle/g, '');
 
@@ -18,9 +18,7 @@ export const modulesService = {
       return moduleUrl;
     }
 
-    return isModule
-      ? 'https://jspm.dev/' + moduleName
-      : 'https://cdn.jsdelivr.net/npm/' + moduleName;
+    return isModule ? 'https://esm.sh/' + moduleName : 'https://cdn.jsdelivr.net/npm/' + moduleName;
   },
 
   getUrl: (path: string, cdn?: CDN) =>

--- a/src/livecodes/services/modules.ts
+++ b/src/livecodes/services/modules.ts
@@ -74,9 +74,9 @@ const getCdnUrl = (modName: string, isModule: boolean, defaultCDN?: CDN) => {
 const TEMPLATES: Array<[RegExp, string]> = [
   [/^(jspm:)(.+)/i, 'https://jspm.dev/$2'],
 
-  [/^(npm:)(.+)/i, 'https://jspm.dev/$2'],
+  [/^(npm:)(.+)/i, 'https://esm.sh/$2'],
 
-  [/^(node:)(.+)/i, 'https://jspm.dev/$2'],
+  [/^(node:)(.+)/i, 'https://esm.sh/$2'],
 
   [/^(skypack:)(.+)/i, 'https://cdn.skypack.dev/$2'],
 

--- a/src/livecodes/templates/starter/preact-starter.ts
+++ b/src/livecodes/templates/starter/preact-starter.ts
@@ -47,6 +47,8 @@ render(<App name="Preact" />, document.body);
   stylesheets: [],
   scripts: [],
   cssPreset: '',
-  imports: {},
   types: {},
+  customSettings: {
+    defaultCDN: 'jspm',
+  },
 };

--- a/src/livecodes/toolspane/test-imports.ts
+++ b/src/livecodes/toolspane/test-imports.ts
@@ -1,6 +1,7 @@
 import { chaiUrl, vendorsBaseUrl } from '../vendors';
 
 export const testImports = {
+  react: 'https://esm.sh/react?dev',
   '@testing-library/dom': vendorsBaseUrl + '@testing-library/dom.js',
   '@testing-library/jest-dom': vendorsBaseUrl + '@testing-library/jest-dom.js',
   '@testing-library/react': vendorsBaseUrl + '@testing-library/react.js',


### PR DESCRIPTION
use esm.sh as the default CDN for modules

jspm.dev that was used before is deprecated: https://jspm.org/jspm-dev-deprecation

to change the default CDN for a project, you may use the [`customSettings.defaultCDN`](https://livecodes.io/docs/features/module-resolution#change-default-cdn) property of the configuration object 