### PR TITLE
monaco editor css nesting workaround

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,7 @@
     <div id="livecodes"></div>
     <div id="loading">
       <img src="livecodes/assets/images/livecodes-logo.svg" alt="LiveCodes logo" />
-      <div id="loading-text">
+      <div id="loading-text" hidden>
         <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path
             d="M2,12A11.2,11.2,0,0,1,13,1.05C12.67,1,12.34,1,12,1a11,11,0,0,0,0,22c.34,0,.67,0,1-.05C6,23,2,17.74,2,12Z"
@@ -84,6 +84,10 @@
         </svg>
         Loading LiveCodes…
       </div>
+      <noscript><div class="noscript">Please enable JavaScript to use LiveCodes</div></noscript>
+      <script>
+        document.querySelector('#loading-text').hidden = false;
+      </script>
     </div>
     <script src="livecodes/{{hash:index.js}}"></script>
   </body>

--- a/src/livecodes/editor/monaco/monaco.ts
+++ b/src/livecodes/editor/monaco/monaco.ts
@@ -71,6 +71,8 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
       ? 'coffeescript'
       : ['rescript', 'reason', 'ocaml'].includes(language)
       ? 'csharp'
+      : language === 'css' // till css nesting is supported (https://github.com/microsoft/monaco-editor/issues/4071)
+      ? 'scss'
       : mapLanguage(language);
 
   const monacoPath = baseUrl + 'vendor/monaco-editor/' + process.env.monacoVersion;

--- a/src/livecodes/styles/index.css
+++ b/src/livecodes/styles/index.css
@@ -39,13 +39,18 @@ body,
   height: 100px;
 }
 
-#loading-text {
+#loading-text,
+.noscript {
   animation: pulsate 3s infinite;
   font-family: monospace;
   font-size: 1.3em;
   margin-top: 15px;
   position: relative;
   text-align: center;
+}
+
+.noscript {
+  animation: none;
 }
 
 #loading-text svg {

--- a/src/livecodes/styles/index.css
+++ b/src/livecodes/styles/index.css
@@ -44,13 +44,21 @@ body,
   animation: pulsate 3s infinite;
   font-family: monospace;
   font-size: 1.3em;
-  margin-top: 15px;
+  margin: 15px auto;
   position: relative;
   text-align: center;
 }
 
 .noscript {
   animation: none;
+  color: red;
+  font-weight: bold;
+  max-width: 80vw;
+}
+
+.noscript::before {
+  content: '\002718';
+  padding-right: 0.5em;
 }
 
 #loading-text svg {


### PR DESCRIPTION
This is a workaround to use monaco editor SCSS instead of CSS to allow support for CSS nesting, till this is supported by Monaco.
See https://github.com/microsoft/monaco-editor/issues/4071

![image](https://github.com/live-codes/livecodes/assets/10176547/3b90c07e-4119-4087-9e40-0fd3ac5586a6)


fixes #515