### PR TITLE
SDK: watch external resources

### DIFF
--- a/docs/docs/sdk/js-ts.md
+++ b/docs/docs/sdk/js-ts.md
@@ -445,7 +445,16 @@ These are the events that can be watched and the description of their callback f
   ) => { remove: () => void }
   ```
 
-- `"code"`: Called when the playground code is changed (see [`getCode`](./js-ts.md#getcode) and [`getConfig`](./js-ts.md#getconfig)).
+- `"code"`: Called when the playground "content" is changed (see [`getCode`](./js-ts.md#getcode) and [`getConfig`](./js-ts.md#getconfig)). This include changes in:
+
+  - Code (in editors)
+  - Editor languages
+  - [CSS processors](../features/css.md#css-processors)
+  - [External resources](../features/external-resources.md)
+  - Project info (e.g. allows adding content in page head and attributes to `<html>` element)
+  - [Custom settings](../advanced/custom-settings.md) (e.g. allows changing [import maps](../features/module-resolution.md#custom-module-resolution))
+  - Project title
+  - [Test](../features/tests.md) code
 
   ```ts
   (

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -2249,6 +2249,7 @@ const handleProcessors = () => {
         if (getConfig().autoupdate) {
           await run();
         }
+        dispatchChangeEvent();
       },
       false,
     );
@@ -3393,10 +3394,10 @@ const handleExternalResources = () => {
       setExternalResourcesMark();
       await setSavedStatus();
       modal.close();
-      dispatchChangeEvent();
       if (getConfig().autoupdate) {
         await run();
       }
+      dispatchChangeEvent();
     };
 
     modal.show(loadingMessage());

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -3393,6 +3393,7 @@ const handleExternalResources = () => {
       setExternalResourcesMark();
       await setSavedStatus();
       modal.close();
+      dispatchChangeEvent();
       if (getConfig().autoupdate) {
         await run();
       }


### PR DESCRIPTION
allows firing `code` event for SDK `watch` method in response to changes in external resources and css processors.

Added docs to clarify sources of changes.

fixes #534