### PR TITLE
remove load buttons from screens

### DIFF
--- a/e2e/specs/compilers.spec.ts
+++ b/e2e/specs/compilers.spec.ts
@@ -123,7 +123,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "Haml"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=Haml');
@@ -163,7 +163,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "Mustache"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=Mustache');
@@ -187,7 +187,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -217,7 +217,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "Handlebars"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=Handlebars');
@@ -241,7 +241,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -271,7 +271,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "Nunjucks"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=Nunjucks');
@@ -295,7 +295,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -325,7 +325,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "EJS"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=EJS');
@@ -349,7 +349,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -379,7 +379,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "Eta"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=Eta');
@@ -403,7 +403,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -433,7 +433,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name":"liquid"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=Liquid');
@@ -457,7 +457,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -487,7 +487,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name":"doT"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=doT');
@@ -511,7 +511,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -541,7 +541,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "Twig"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=Twig');
@@ -565,7 +565,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');
@@ -595,7 +595,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"data":{"name": "art-template"}}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=art-template');
@@ -619,7 +619,7 @@ const title = "World";
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"template":{"prerender": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=JavaScript');

--- a/e2e/specs/custom-settings.spec.ts
+++ b/e2e/specs/custom-settings.spec.ts
@@ -14,7 +14,7 @@ test.describe('Custom Settings', () => {
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"asciidoc": { standalone: true }}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 1)');
     await app.click('text=AsciiDoc');
@@ -37,7 +37,7 @@ test.describe('Custom Settings', () => {
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"scss": {"style": "compressed"}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 2)');
     await app.click('text=SCSS');
@@ -64,7 +64,7 @@ test.describe('Custom Settings', () => {
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.insertText(`{"sass": {"style": "compressed"}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 2)');
     await app.click('text=Sass');
@@ -94,7 +94,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"less": {"math": "always"}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 2)');
     await app.click('text=Less');
@@ -117,7 +117,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"postcssImportUrl": false}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click('text=CSS');
     await waitForEditorFocus(app);
@@ -140,7 +140,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"autoprefixer": {"add": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 2)');
     await app.click('text=autoprefixer');
@@ -164,7 +164,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"postcssPresetEnv": {"stage": 3}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 2)');
     await app.click('text=Preset Env');
@@ -190,7 +190,7 @@ body
     await page.keyboard.type(
       `{"tailwindcss": {"theme": {"extend": {"colors": {"dark-blue-800": "#0A214C"}}}}}`,
     );
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click('text=HTML');
     await waitForEditorFocus(app);
@@ -225,7 +225,7 @@ body
     await page.keyboard.type(
       `{"windicss": {"theme": {"extend": {"colors": {"dark-blue-800": "#0A214C"}}}}}`,
     );
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click('text=HTML');
     await waitForEditorFocus(app);
@@ -257,7 +257,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"babel": {"sourceMaps": "inline"}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=Babel');
@@ -280,7 +280,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"typescript": {"target": "es5"}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=TypeScript');
@@ -303,7 +303,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"flow": {"pretty": true}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=Flow');
@@ -330,7 +330,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"svelte": {"css": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await waitForResultUpdate();
 
@@ -350,7 +350,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"stencil": {"sourceMap": true}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await waitForResultUpdate();
 
@@ -368,7 +368,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"coffeescript": {"bare": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=CoffeeScript');
@@ -391,7 +391,7 @@ body
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{"livescript": {"bare": false}}`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await app.click(':nth-match([data-hint="Change Language"], 3)');
     await app.click('text=LiveScript');

--- a/e2e/specs/sfc-processors.spec.ts
+++ b/e2e/specs/sfc-processors.spec.ts
@@ -110,7 +110,7 @@ demo
     await page.keyboard.press('Control+A');
     await page.keyboard.press('Delete');
     await page.keyboard.type(`{ "riot": { "template": "pug" } }`);
-    await app.click('button:has-text("Load"):visible');
+    await app.locator('.close-button').click();
 
     await waitForResultUpdate();
 

--- a/src/livecodes/UI/info.ts
+++ b/src/livecodes/UI/info.ts
@@ -21,7 +21,6 @@ export const createProjectInfoUI = async (
   config: Config,
   storage: ProjectStorage,
   modal: ReturnType<typeof createModal>,
-  eventsManager: ReturnType<typeof createEventsManager>,
   onUpdate: (
     title: string,
     description: string,
@@ -33,7 +32,7 @@ export const createProjectInfoUI = async (
   const div = document.createElement('div');
   div.innerHTML = infoScreen;
   const projectInfoContainer = div.firstChild as HTMLElement;
-  modal.show(projectInfoContainer);
+  modal.show(projectInfoContainer, { onClose: () => updateInfo() });
 
   const titleInput = UI.getInfoTitleInput();
   titleInput.value = config.title;
@@ -54,7 +53,7 @@ export const createProjectInfoUI = async (
   const tagsInput = UI.getInfoTagsInput();
   tagsInput.value = removeDuplicates(config.tags).join(', ');
 
-  eventsManager.addEventListener(UI.getUpdateInfoButton(), 'click', async () => {
+  const updateInfo = async () => {
     UI.getProjectTitleElement().textContent = titleInput.value;
     onUpdate(
       titleInput.value,
@@ -63,8 +62,7 @@ export const createProjectInfoUI = async (
       htmlAttrsTextarea.value,
       getTags(tagsInput.value),
     );
-    modal.close();
-  });
+  };
 
   loadStylesheet(tagifyBaseUrl + 'tagify.css', 'tagify-styles');
   await loadScript(tagifyBaseUrl + 'tagify.min.js', 'Tagify');

--- a/src/livecodes/UI/info.ts
+++ b/src/livecodes/UI/info.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-internal-modules */
-import type { createEventsManager } from '../events';
 import { infoScreen } from '../html';
 import type { createModal } from '../modal';
 import * as UI from '../UI';

--- a/src/livecodes/UI/resources.ts
+++ b/src/livecodes/UI/resources.ts
@@ -5,11 +5,7 @@ import type { Config, CssPresetId, PkgInfo } from '../models';
 import { resourcesScreen } from '../html';
 import { pkgInfoService } from '../services/pkgInfo';
 import { debounce, hideOnClickOutside } from '../utils/utils';
-import {
-  getExternalResourcesCssPresetInputs,
-  getExternalResourcesTextareas,
-  getLoadResourcesButton,
-} from './selectors';
+import { getExternalResourcesCssPresetInputs, getExternalResourcesTextareas } from './selectors';
 
 interface PkgInfoWithDefaultFiles extends PkgInfo {
   files: {
@@ -38,7 +34,7 @@ export const createExternalResourcesUI = ({
   const div = document.createElement('div');
   div.innerHTML = resourcesScreen;
   const resourcesContainer = div.firstChild as HTMLElement;
-  modal.show(resourcesContainer);
+  modal.show(resourcesContainer, { onClose: () => updateResources() });
 
   const externalResources = getExternalResourcesTextareas();
   externalResources.forEach((textarea) => {
@@ -266,7 +262,7 @@ export const createExternalResourcesUI = ({
     });
   });
 
-  eventsManager.addEventListener(getLoadResourcesButton(), 'click', async () => {
+  const updateResources = async () => {
     externalResources.forEach((textarea) => {
       const resource = textarea.dataset.resource as ResourceType;
       deps.setConfig({
@@ -289,5 +285,5 @@ export const createExternalResourcesUI = ({
     });
 
     deps.loadResources();
-  });
+  };
 };

--- a/src/livecodes/UI/selectors.ts
+++ b/src/livecodes/UI/selectors.ts
@@ -258,23 +258,14 @@ export const getInfoDescription = /* @__PURE__ */ () =>
 export const getInfoTagsInput = /* @__PURE__ */ () =>
   document.querySelector('#info-container input#tags-input') as HTMLInputElement;
 
-export const getUpdateInfoButton = /* @__PURE__ */ () =>
-  document.querySelector<HTMLElement>('#info-container #info-update-btn');
-
 export const getExternalResourcesTextareas = /* @__PURE__ */ () =>
   document.querySelectorAll<HTMLTextAreaElement>('#resources-container textarea');
 
 export const getExternalResourcesCssPresetInputs = /* @__PURE__ */ () =>
   document.querySelectorAll<HTMLInputElement>('#resources-container input[type="radio"]');
 
-export const getLoadResourcesButton = /* @__PURE__ */ () =>
-  document.querySelector<HTMLElement>('#resources-container #resources-load-btn');
-
 export const getCustomSettingsEditor = /* @__PURE__ */ () =>
   document.querySelector<HTMLElement>('#custom-settings-container #custom-settings-editor');
-
-export const getLoadCustomSettingsButton = /* @__PURE__ */ () =>
-  document.querySelector<HTMLElement>('#custom-settings-container #custom-settings-load-btn');
 
 export const getTestEditor = /* @__PURE__ */ () =>
   document.querySelector<HTMLElement>('#test-editor-container #test-editor');

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -3186,13 +3186,7 @@ const handleProjectInfo = () => {
     dispatchChangeEvent();
   };
   const createProjectInfo = () =>
-    createProjectInfoUI(
-      getConfig(),
-      stores.projects || fakeStorage,
-      modal,
-      eventsManager,
-      onUpdate,
-    );
+    createProjectInfoUI(getConfig(), stores.projects || fakeStorage, modal, onUpdate);
 
   eventsManager.addEventListener(UI.getProjectInfoLink(), 'click', createProjectInfo, false);
   registerScreen('info', createProjectInfo);
@@ -3425,7 +3419,6 @@ const handleExternalResources = () => {
     const loadResources = async () => {
       setExternalResourcesMark();
       await setSavedStatus();
-      modal.close();
       if (getConfig().autoupdate) {
         await run();
       }
@@ -3466,7 +3459,8 @@ const handleCustomSettings = () => {
     div.innerHTML = customSettingsScreen;
     const customSettingsContainer = div.firstChild as HTMLElement;
     modal.show(customSettingsContainer, {
-      onClose: () => {
+      onClose: async () => {
+        await loadCustomSettings();
         customSettingsEditor?.destroy();
       },
     });
@@ -3490,7 +3484,7 @@ const handleCustomSettings = () => {
     customSettingsEditor = await createEditor(options);
     customSettingsEditor?.focus();
 
-    eventsManager.addEventListener(UI.getLoadCustomSettingsButton(), 'click', async () => {
+    const loadCustomSettings = async () => {
       let customSettings: CustomSettings = {};
       const editorContent = customSettingsEditor?.getValue() || '{}';
       try {
@@ -3516,12 +3510,11 @@ const handleCustomSettings = () => {
         }
       }
       customSettingsEditor?.destroy();
-      modal.close();
       if (getConfig().autoupdate) {
         await run();
       }
       dispatchChangeEvent();
-    });
+    };
   };
   eventsManager.addEventListener(
     UI.getCustomSettingsLink(),

--- a/src/livecodes/html/custom-settings.html
+++ b/src/livecodes/html/custom-settings.html
@@ -4,7 +4,6 @@
     <div class="modal-screen">
       <label>Custom Settings JSON</label>
       <div id="custom-settings-editor" class="editor custom-editor"></div>
-      <button id="custom-settings-load-btn" class="wide-button">Load</button>
     </div>
     <!-- TODO: add link to documentations -->
     <!-- <div class="description">See documentations for details.</div> -->

--- a/src/livecodes/html/external-resources.html
+++ b/src/livecodes/html/external-resources.html
@@ -60,8 +60,6 @@
           <label class="radio-label" for="resources-css-preset-reset-css">Reset CSS</label>
         </span>
       </div>
-
-      <button id="resources-load-btn" class="wide-button">Load</button>
     </div>
   </div>
 </div>

--- a/src/livecodes/html/project-info.html
+++ b/src/livecodes/html/project-info.html
@@ -15,7 +15,6 @@
       <textarea id="html-attrs-textarea" placeholder='lang="en" class="my-class"'></textarea>
       <label for="tags-input">Tags</label>
       <input id="tags-input" type="text" />
-      <button id="info-update-btn" class="wide-button">Update</button>
     </div>
   </div>
 </div>

--- a/src/livecodes/styles/app.scss
+++ b/src/livecodes/styles/app.scss
@@ -1968,7 +1968,7 @@ i.arrow {
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.176);
     margin-bottom: 1em;
     min-height: calc(80% - 100px);
-    padding: 0.7em;
+    padding: 1.5em 0.7em;
   }
 
   .tab-content {


### PR DESCRIPTION
Now closing a screen applies the settings without the need to click on a load button.

This change is applied to:
- External resources
- Project info
- Custom settings