### PR TITLE
use custom build of monaco

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     "ToolsPane",
     "Modes",
     "Import-maps",
-    "Formatter"
+    "Formatter",
+    "Build"
   ]
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const { applyHash } = require('./hash');
 const { injectCss } = require('./inject-css');
-const { buildVendors, typescriptVersion } = require('./vendors');
+const { buildVendors } = require('./vendors');
 const { buildStyles } = require('./styles');
 const { arrToObj, mkdir, uint8arrayToString, iife, getFileNames, getEnvVars } = require('./utils');
 
@@ -58,7 +58,6 @@ const baseOptions = {
   sourcemap: false,
   sourcesContent: true,
   define: {
-    'process.env.TYPESCRIPT_VERSION': `"${typescriptVersion}"`,
     ...getEnvVars(devMode),
   },
   loader: { '.html': 'text', '.ttf': 'file' },

--- a/scripts/vendors.js
+++ b/scripts/vendors.js
@@ -2,8 +2,6 @@ const esbuild = require('esbuild');
 const { getEnvVars } = require('./utils');
 const pkg = require('../package.json');
 
-const typescriptVersion = '5.5.3';
-
 const buildVendors = () => {
   const srcDir = 'src/livecodes/editor/monaco/';
   const outputDir = 'build/livecodes/';
@@ -34,7 +32,6 @@ const buildVendors = () => {
     define: {
       global: 'window',
       'process.env.NODE_ENV': '"production"',
-      'process.env.TYPESCRIPT_VERSION': `"${typescriptVersion}"`,
       ...getEnvVars(false),
     },
   };
@@ -124,7 +121,7 @@ const buildVendors = () => {
   });
 };
 
-module.exports = { buildVendors, typescriptVersion };
+module.exports = { buildVendors };
 
 if (require.main === module) {
   buildVendors();

--- a/src/livecodes/UI/qrcode.ts
+++ b/src/livecodes/UI/qrcode.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-internal-modules */
-import { bypassAMD, loadScript, safeName } from '../utils/utils';
+import { loadScript, safeName } from '../utils/utils';
 import { qrcodeUrl } from '../vendors';
 
 export const generateQrCode = async ({
@@ -13,7 +13,7 @@ export const generateQrCode = async ({
   title?: string;
   logo?: string;
 }) => {
-  const QRCode: any = await bypassAMD(() => loadScript(qrcodeUrl, 'QRCode'));
+  const QRCode: any = await loadScript(qrcodeUrl, 'QRCode');
   container.style.visibility = 'hidden';
   const qr = new QRCode(container, {
     text: url,

--- a/src/livecodes/UI/sync-ui.ts
+++ b/src/livecodes/UI/sync-ui.ts
@@ -6,7 +6,6 @@ import type { User, UserData } from '../models';
 import { syncScreen } from '../html';
 import { autoCompleteUrl } from '../vendors';
 import { getUserRepos } from '../services/github';
-import { bypassAMD, loadScript } from '../utils/utils';
 import {
   getExistingRepoAutoSync,
   getExistingRepoForm,
@@ -208,33 +207,36 @@ export const createSyncUI = async ({
 
   if (!user) return;
 
-  bypassAMD(() => loadScript(autoCompleteUrl, 'autoComplete')).then(async (autoComplete: any) => {
-    const repos = await getUserRepos(user, 'all');
+  if (!(globalThis as any).autoComplete) {
+    await import(autoCompleteUrl);
+  }
+  const autoComplete = (globalThis as any).autoComplete;
 
-    eventsManager.addEventListener(existingRepoNameInput, 'init', () => {
-      existingRepoNameInput.focus();
-    });
+  const repos = await getUserRepos(user, 'all');
 
-    const inputSelector = '#' + existingRepoNameInput.id;
-    if (!document.querySelector(inputSelector)) return;
-    const autoCompleteJS = new autoComplete({
-      selector: inputSelector,
-      placeHolder: 'Search your repos...',
-      data: {
-        src: repos,
+  eventsManager.addEventListener(existingRepoNameInput, 'init', () => {
+    existingRepoNameInput.focus();
+  });
+
+  const inputSelector = '#' + existingRepoNameInput.id;
+  if (!document.querySelector(inputSelector)) return;
+  const autoCompleteJS = new autoComplete({
+    selector: inputSelector,
+    placeHolder: 'Search your repos...',
+    data: {
+      src: repos,
+    },
+    resultItem: {
+      highlight: {
+        render: true,
       },
-      resultItem: {
-        highlight: {
-          render: true,
-        },
-      },
-    });
+    },
+  });
 
-    eventsManager.addEventListener(autoCompleteJS.input, 'selection', function (event: any) {
-      const feedback = event.detail;
-      autoCompleteJS.input.blur();
-      const selection = feedback.selection.value;
-      autoCompleteJS.input.value = selection;
-    });
+  eventsManager.addEventListener(autoCompleteJS.input, 'selection', function (event: any) {
+    const feedback = event.detail;
+    autoCompleteJS.input.blur();
+    const selection = feedback.selection.value;
+    autoCompleteJS.input.value = selection;
   });
 };

--- a/src/livecodes/storage/storage.ts
+++ b/src/livecodes/storage/storage.ts
@@ -1,5 +1,7 @@
+/* eslint-disable import/no-internal-modules */
 import { localforageUrl } from '../vendors';
 import { createPub } from '../events';
+import { loadScript } from '../utils/utils';
 import type { Storage, StoreName } from './models';
 import { fakeStorage } from './fake-storage';
 
@@ -13,7 +15,7 @@ export const generateId = () =>
 
 const loadLocalforage = async (store: string) => {
   if (!localforage) {
-    localforage = (await import(localforageUrl)).default as LocalForage;
+    localforage = (await loadScript(localforageUrl, 'localforage')) as LocalForage;
     localforage.config({
       name: dbName,
     });

--- a/src/livecodes/vendors.ts
+++ b/src/livecodes/vendors.ts
@@ -246,7 +246,7 @@ export const juliaWasmBaseUrl = /* @__PURE__ */ getUrl('@chriskoch/julia-wasm@1.
 
 export const liquidJsUrl = /* @__PURE__ */ getUrl('liquidjs@10.14.0/dist/liquid.browser.min.js');
 
-export const localforageUrl = /* @__PURE__ */ getModuleUrl('localforage@1.10.0');
+export const localforageUrl = /* @__PURE__ */ getUrl('localforage@1.10.0/dist/localforage.min.js');
 
 export const luaUrl = /* @__PURE__ */ getUrl('fengari-web@0.1.4/dist/fengari-web.js');
 
@@ -272,7 +272,7 @@ export const mermaidCdnUrl = /* @__PURE__ */ getUrl('mermaid@10.2.2/dist/mermaid
 
 export const mjmlUrl = /* @__PURE__ */ getUrl('mjml-browser@4.15.3/lib/index.js');
 
-export const monacoBaseUrl = /* @__PURE__ */ `https://typescript.azureedge.net/cdn/${process.env.TYPESCRIPT_VERSION}/monaco/min/vs`;
+export const monacoBaseUrl = /* @__PURE__ */ getUrl('@live-codes/monaco-editor@0.1.0/dist/');
 
 export const monacoEmacsUrl = /* @__PURE__ */ getUrl('monaco-emacs@0.3.0/dist/monaco-emacs.js');
 
@@ -402,9 +402,7 @@ export const thememirrorBaseUrl = /* @__PURE__ */ getUrl('thememirror@2.0.1/dist
 
 export const twigUrl = /* @__PURE__ */ getUrl('twig@1.17.1/twig.min.js');
 
-export const typescriptUrl = /* @__PURE__ */ getUrl(
-  `typescript@${process.env.TYPESCRIPT_VERSION}/lib/typescript.js`,
-);
+export const typescriptUrl = /* @__PURE__ */ getUrl(`typescript@5.5.3/lib/typescript.js`);
 
 export const typescriptVfsUrl = /* @__PURE__ */ getUrl('@typescript/vfs@1.5.3/dist/vfs.esm.js');
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] ♻️ Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description


This PR uses a [custom build](https://github.com/live-codes/monaco-editor) of Monaco editor, which allows:
- Using esm build (and getting rid of problems related to `require` & `anonymous define() module`).
- Loading from npm mirroring CDNs. The editor now loads much faster.
- The custom build allows choosing TypeScript version to include.
