### PR TITLE
fix formatting on monaco

### DIFF
--- a/src/livecodes/UI/editor-settings.ts
+++ b/src/livecodes/UI/editor-settings.ts
@@ -30,7 +30,6 @@ export const createEditorSettingsUI = async ({
     loadTypes: (code: string) => Promise<EditorLibrary[]>;
     getFormatFn: () => Promise<FormatFn>;
     changeSettings: (newConfig: Partial<UserConfig>) => void;
-    onClose: () => Promise<void>;
   };
 }) => {
   const userConfig = deps.getUserConfig();
@@ -42,7 +41,7 @@ export const createEditorSettingsUI = async ({
     isAsync: true,
     scrollToSelector,
     onClose: () => {
-      deps.onClose?.();
+      editor?.destroy();
     },
   });
 

--- a/src/livecodes/UI/editor-settings.ts
+++ b/src/livecodes/UI/editor-settings.ts
@@ -30,6 +30,7 @@ export const createEditorSettingsUI = async ({
     loadTypes: (code: string) => Promise<EditorLibrary[]>;
     getFormatFn: () => Promise<FormatFn>;
     changeSettings: (newConfig: Partial<UserConfig>) => void;
+    onClose: () => Promise<void>;
   };
 }) => {
   const userConfig = deps.getUserConfig();
@@ -37,7 +38,13 @@ export const createEditorSettingsUI = async ({
   const div = document.createElement('div');
   div.innerHTML = editorSettingsScreen;
   const editorSettingsContainer = div.firstChild as HTMLElement;
-  modal.show(editorSettingsContainer, { isAsync: true, scrollToSelector });
+  modal.show(editorSettingsContainer, {
+    isAsync: true,
+    scrollToSelector,
+    onClose: () => {
+      deps.onClose?.();
+    },
+  });
 
   const previewContainer = editorSettingsContainer.querySelector<HTMLElement>(
     '#editor-settings-preview-container',

--- a/src/livecodes/UI/embed-ui.ts
+++ b/src/livecodes/UI/embed-ui.ts
@@ -33,7 +33,7 @@ export const createEmbedUI = async ({
   const div = document.createElement('div');
   div.innerHTML = embedScreen;
   const embedContainer = div.firstChild as HTMLElement;
-  modal.show(embedContainer, { isAsync: true });
+  modal.show(embedContainer, { isAsync: true, onClose: () => editor?.destroy() });
 
   const previewContainer = embedContainer.querySelector<HTMLElement>('#embed-preview-container');
   const form = embedContainer.querySelector<HTMLFormElement>('#embed-form');

--- a/src/livecodes/UI/snippets.ts
+++ b/src/livecodes/UI/snippets.ts
@@ -21,6 +21,8 @@ import {
   getSnippetTitleInput,
 } from './selectors';
 
+let editor: CodeEditor | undefined;
+
 const textLanguage = { name: 'text', title: 'Plain Text', editorLanguage: '' };
 const getLanguage = (name: Language) =>
   name === textLanguage.name ? textLanguage.title : getLanguageTitle(name);
@@ -449,7 +451,7 @@ export const createSnippetsList = async ({
   await showList(savedSnippets);
 
   const getSnippets = () => snippetsStorage.getAllData();
-  modal.show(listContainer, { isAsync: true });
+  modal.show(listContainer, { isAsync: true, onClose: () => editor?.destroy() });
   organizeSnippets(getSnippets, showList, eventsManager);
 };
 
@@ -516,7 +518,7 @@ export const createAddSnippetContainer = async ({
       languageSelect.appendChild(option);
     });
 
-  const editor = await deps.createEditorFn({
+  editor = await deps.createEditorFn({
     container: snippetEditor,
     editorId: 'add-snippet',
     language: selectedLanguage,
@@ -535,7 +537,7 @@ export const createAddSnippetContainer = async ({
       title: snippetTitleInput.value,
       description: snippetDescriptionArea.value,
       language: languageSelect.value as Language,
-      code: editor.getValue(),
+      code: editor?.getValue() || '',
       lastModified: Date.now(),
     };
 
@@ -544,6 +546,7 @@ export const createAddSnippetContainer = async ({
 
     notifications.success('Snippet locally saved to device!');
     showScreen('snippets');
+    editor?.destroy();
   };
 
   eventsManager.addEventListener(
@@ -551,6 +554,7 @@ export const createAddSnippetContainer = async ({
     'click',
     () => {
       showScreen('snippets');
+      editor?.destroy();
     },
     false,
   );
@@ -559,7 +563,7 @@ export const createAddSnippetContainer = async ({
     languageSelect,
     'change',
     () => {
-      editor.setLanguage(languageSelect.value as Language);
+      editor?.setLanguage(languageSelect.value as Language);
     },
     false,
   );

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -3507,11 +3507,7 @@ const handleCustomSettings = () => {
     const div = document.createElement('div');
     div.innerHTML = customSettingsScreen;
     const customSettingsContainer = div.firstChild as HTMLElement;
-    modal.show(customSettingsContainer, {
-      onClose: () => {
-        customSettingsEditor?.destroy();
-      },
-    });
+    modal.show(customSettingsContainer, { onClose: () => customSettingsEditor?.destroy() });
 
     const options: EditorOptions = {
       baseUrl,
@@ -3673,18 +3669,7 @@ const handleTestEditor = () => {
     const div = document.createElement('div');
     div.innerHTML = testEditorScreen;
     const testEditorContainer = div.firstChild as HTMLElement;
-    modal.show(testEditorContainer, {
-      onClose: () => {
-        testEditor?.destroy();
-
-        // fix monaco mixing up model of script with test editors
-        if (editors.script.monaco) {
-          formatter
-            .getFormatFn(getConfig().script.language)
-            .then((fn) => editors.script.registerFormatter(fn));
-        }
-      },
-    });
+    modal.show(testEditorContainer, { onClose: () => testEditor?.destroy() });
 
     const testLanguage: Language = config.tests?.language || 'tsx';
     const editorLanguage: Language = 'jsx';

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -3328,14 +3328,8 @@ const handleEditorSettings = () => {
         getUserConfig: () => getUserConfig(getConfig()),
         createEditor,
         loadTypes: async (code: string) => typeLoader.load(code, {}),
-        getFormatFn: () => formatter.getFormatFn('tsx'),
+        getFormatFn: () => formatter.getFormatFn('jsx'),
         changeSettings,
-        onClose: async () => {
-          // undo overwriting by editor settings code editor
-          editors.script.registerFormatter(
-            await formatter.getFormatFn(editors.script.getLanguage()),
-          );
-        },
       },
     });
   };

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -3330,6 +3330,12 @@ const handleEditorSettings = () => {
         loadTypes: async (code: string) => typeLoader.load(code, {}),
         getFormatFn: () => formatter.getFormatFn('tsx'),
         changeSettings,
+        onClose: async () => {
+          // undo overwriting by editor settings code editor
+          editors.script.registerFormatter(
+            await formatter.getFormatFn(editors.script.getLanguage()),
+          );
+        },
       },
     });
   };


### PR DESCRIPTION
this fixes an issue where opening the editor setting screen, caused formatting on script editor to output the editor settings editor content. This occurred only on monaco.
