### PR TITLE
fix external resources in firefox

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "Modes",
     "Import-maps",
     "Formatter",
-    "Build"
+    "Build",
+    "services"
   ]
 }

--- a/src/livecodes/services/pkgInfo.ts
+++ b/src/livecodes/services/pkgInfo.ts
@@ -1,4 +1,6 @@
+/* eslint-disable import/no-internal-modules */
 import type { APIError, CDNService, PkgInfo } from '../models';
+import { isFirefox } from '../utils/utils';
 import { removeCDNPrefix, removeSpecifier } from './utils';
 
 // see: https://github.com/jsdelivr/www.jsdelivr.com/blob/master/src/public/js/utils/search.js
@@ -18,7 +20,8 @@ const attributesToRetrieve = ['name', 'description', 'homepage', 'repository.url
 const apiEndpoint = 'https://data.jsdelivr.com/v1';
 
 const jsDelivrHeaders = {
-  'User-Agent': 'https://livecodes.io',
+  // https://github.com/live-codes/livecodes/issues/628
+  ...(isFirefox() ? {} : { 'User-Agent': 'https://livecodes.io' }),
 };
 
 interface APIPkgFiles {

--- a/src/livecodes/styles/app.scss
+++ b/src/livecodes/styles/app.scss
@@ -2282,6 +2282,7 @@ i.arrow {
       .search-result-item-files {
         display: flex;
         flex-wrap: wrap;
+        justify-content: space-around;
 
         > span {
           display: flex;
@@ -2298,8 +2299,10 @@ i.arrow {
           display: flex;
           gap: 0.5em;
           height: 20px;
+          justify-content: center;
           padding: 0.7em;
           text-decoration: none;
+          width: 6em;
         }
 
         a:hover {

--- a/src/livecodes/utils/utils.ts
+++ b/src/livecodes/utils/utils.ts
@@ -68,6 +68,11 @@ export const isMobile = /* @__PURE__ */ () => {
   return mobile;
 };
 
+export const isFirefox = /* @__PURE__ */ () => {
+  const userAgent = navigator.userAgent.toLowerCase();
+  return userAgent.includes('firefox') || userAgent.includes('fxios');
+};
+
 export const isRelativeUrl = /* @__PURE__ */ (url?: string) =>
   !url?.startsWith('http') && !url?.startsWith('data:');
 


### PR DESCRIPTION
This PR fixes CORS errors in external resources search in Firefox.

This is related to setting `User-Agent` header in jsDelivr API requests.

This is encouraged by the [jsDelivr API docs](https://www.jsdelivr.com/docs/data.jsdelivr.com):

> ## Let us know how you use this API
> If you create a tool/plugin/etc. which uses this API, please include a link to your tool in the **User-Agent** header so that we can learn more about how this API is being used.

So, this header was set to "https://livecodes.io"

This works well in all browsers, except Firefox which had CORS error.
So this PR detects Firefox browser, and avoids sending this header.

In addition, a mismatch in styling between browsers in the external resources search result menu was fixed.

fixes #628