### PR TITLE
fix(ci): disable placeholder conversion during `i18n-update-push`

### DIFF
--- a/scripts/i18n-upload.mjs
+++ b/scripts/i18n-upload.mjs
@@ -11,6 +11,7 @@ const uploadParams = {
   // Since we're uploading files from Github where related history is stored, we can safely use cleanup_mode
   cleanup_mode: true,
   replace_modified: true,
+  convert_placeholders: false,
 };
 
 const pushToLokalise = () => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ♻️ Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description
By default, Lokalise's [file upload API](https://developers.lokalise.com/reference/upload-a-file) will try to convert placeholders into [their universal format](https://docs.lokalise.com/en/articles/1400511-lokalise-universal-placeholders), which is not our desired behavior and causes several QA issues ("Placeholder/HTML mismatch") to be raised.

This PR fixes this issue by explicitly setting the `convert_placeholders` flag to false.

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentations?

- [ ] 📓 docs (./docs)
- [ ] 📕 storybook (./storybook)
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## Are there any post-deployment tasks we need to perform?
After merge, please manually run the following to fix data existed on the branch `gigamaster/dev-gui` which will be used for next release:

```bash
npm run i18n-export
npm run i18n-update-push -- gigamaster/dev-gui --force
```

Note that `LOKALISE_PROJECT_ID` and `LOKALISE_API_TOKEN` should be set before running these commands.

I've already done a test run with my fork repo and [the staging project on Lokalise](https://app.lokalise.com/project/60810062671f99b3883fb4.07995509). You might want to have a test there as well - just fill `LOKALISE_PROJECT_ID` with `60810062671f99b3883fb4.07995509`, replace `gigamaster/dev-gui` with `master` and everything should be fine.

Whether the data on the `master` branch should be updated might be left for discussion. We can either update it using i18n entries exported from the codebasse before merging #630, or just leave it as is for now and update it later when merging `gigamaster/dev-gui` to `master` on Lokalise.
