### PR TITLE
upgrade Svelte to version 5

### DIFF
--- a/src/livecodes/languages/svelte/lang-svelte.ts
+++ b/src/livecodes/languages/svelte/lang-svelte.ts
@@ -1,5 +1,5 @@
 import type { LanguageSpecs } from '../../models';
-import { svelteRuntimeBaseUrl, vendorsBaseUrl } from '../../vendors';
+import { svelteBaseUrl } from '../../vendors';
 import { parserPlugins } from '../prettier';
 
 export const svelte: LanguageSpecs = {
@@ -10,16 +10,18 @@ export const svelte: LanguageSpecs = {
     pluginUrls: [parserPlugins.html, parserPlugins.babel],
   },
   compiler: {
-    url: vendorsBaseUrl + 'svelte/svelte-compiler.min.js',
+    url: svelteBaseUrl + 'compiler/index.js',
     factory: (_config, baseUrl) => {
       (self as any).importScripts(baseUrl + '{{hash:lang-svelte-compiler.js}}');
       return (self as any).createSvelteCompiler();
     },
     imports: {
-      svelte: svelteRuntimeBaseUrl + 'index.js',
-      'svelte/internal': svelteRuntimeBaseUrl + 'index.js',
-      'svelte/internal/disclose-version': svelteRuntimeBaseUrl + 'disclose-version/index.js',
+      svelte: svelteBaseUrl + 'src/index-client.js',
+      'svelte/internal/client': svelteBaseUrl + 'src/internal/client/index.js',
+      'svelte/internal/disclose-version': svelteBaseUrl + 'src/internal/disclose-version.js',
+      'esm-env': 'https://esm.sh/esm-env',
     },
+    inlineScript: 'globalThis.process = { env: { NODE_ENV: "production" } };',
   },
   extensions: ['svelte'],
   editor: 'script',

--- a/src/livecodes/templates/starter/svelte-starter.ts
+++ b/src/livecodes/templates/starter/svelte-starter.ts
@@ -18,7 +18,7 @@ export const svelteStarter: Template = {
     content: `
 <script>
   let title = "Svelte";
-  let counter = 0;
+  let counter = $state(0);
   function increment() {
     counter += 1;
   }

--- a/src/livecodes/vendors.ts
+++ b/src/livecodes/vendors.ts
@@ -380,9 +380,7 @@ export const stencilUrl = /* @__PURE__ */ getUrl('@stencil/core@3.2.2/compiler/s
 
 export const stylisUrl = /* @__PURE__ */ getUrl('stylis@4.3.2/dist/umd/stylis.js');
 
-export const svelteRuntimeBaseUrl = /* @__PURE__ */ getUrl(
-  'https://unpkg.com/svelte@4.0.0/src/runtime/internal/',
-);
+export const svelteBaseUrl = /* @__PURE__ */ getUrl('svelte@5.10.0/');
 
 export const svgbobWasmCdnUrl = /* @__PURE__ */ getUrl('svgbob-wasm@0.4.1-a0/svgbob_wasm_bg.wasm');
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ♻️ Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description

This PR upgrades Svelte to version 5

The Svelte starter template was updated to use runes.

