### PR TITLE
relative line numbers in code editors

### DIFF
--- a/docs/docs/configuration/configuration-object.md
+++ b/docs/docs/configuration/configuration-object.md
@@ -627,11 +627,12 @@ The number of spaces per indentation-level. Also used in [code formatting](../fe
 
 ### `lineNumbers`
 
-Type: [`boolean`](../api/interfaces/Config.md#linenumbers)
+Type: [`boolean | "relative"`](../api/interfaces/Config.md#linenumbers)
 
 Default: `true`
 
-Show line numbers in [code editor](../features/editor-settings.md).
+Show line numbers in [code editor](../features/editor-settings.md).  
+If set to `"relative"`, line numbers are shown relative to the current line. This can be useful with [vim mode](#editormode).
 
 ### `wordWrap`
 

--- a/scripts/vendors.js
+++ b/scripts/vendors.js
@@ -75,6 +75,7 @@ const buildVendors = () => {
       'codemirror-emacs.ts',
       'codemirror-emmet.ts',
       'codemirror-codeium.ts',
+      'codemirror-line-numbers-relative.ts',
       'languages/codemirror-lang-json.ts',
       'languages/codemirror-lang-markdown.ts',
       'languages/codemirror-lang-python.ts',

--- a/src/livecodes/config/validate-config.ts
+++ b/src/livecodes/config/validate-config.ts
@@ -162,7 +162,9 @@ export const validateConfig = (config: Partial<Config>): Partial<Config> => {
     ...(is(config.fontSize, 'number') ? { fontSize: Number(config.fontSize) } : {}),
     ...(is(config.useTabs, 'boolean') ? { useTabs: config.useTabs } : {}),
     ...(is(config.tabSize, 'number') ? { tabSize: Number(config.tabSize) } : {}),
-    ...(is(config.lineNumbers, 'boolean') ? { lineNumbers: config.lineNumbers } : {}),
+    ...(is(config.lineNumbers, 'boolean') || config.lineNumbers === 'relative'
+      ? { lineNumbers: config.lineNumbers }
+      : {}),
     ...(is(config.wordWrap, 'boolean') ? { wordWrap: config.wordWrap } : {}),
     ...(is(config.closeBrackets, 'boolean') ? { closeBrackets: config.closeBrackets } : {}),
     ...(is(config.semicolons, 'boolean') ? { semicolons: config.semicolons } : {}),

--- a/src/livecodes/editor/codejar/codejar.ts
+++ b/src/livecodes/editor/codejar/codejar.ts
@@ -334,7 +334,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     `;
     document.head.appendChild(styleEl);
     setTheme(settings.theme, settings.editorTheme);
-    preElement.classList.toggle('line-numbers', editorOptions.lineNumbers);
+    preElement.classList.toggle('line-numbers', Boolean(editorOptions.lineNumbers));
     highlight();
   };
   changeSettings(options);

--- a/src/livecodes/editor/codemirror/codemirror-line-numbers-relative.ts
+++ b/src/livecodes/editor/codemirror/codemirror-line-numbers-relative.ts
@@ -1,0 +1,70 @@
+// from https://github.com/jsjoeio/codemirror-line-numbers-relative
+
+import { EditorView, type ViewUpdate, lineNumbers, gutter, GutterMarker } from '@codemirror/view';
+import { Compartment, type EditorState, type Extension } from '@codemirror/state';
+
+const relativeLineNumberGutter = new Compartment();
+
+class Marker extends GutterMarker {
+  /** The text to render in gutter */
+  public text: string;
+
+  public constructor(text: string) {
+    super();
+    this.text = text;
+  }
+
+  public toDOM() {
+    return document.createTextNode(this.text);
+  }
+}
+
+const absoluteLineNumberGutter = gutter({
+  lineMarker: (view, line) => {
+    const lineNo = view.state.doc.lineAt(line.from).number;
+    const absoluteLineNo = new Marker(lineNo.toString());
+    const cursorLine = view.state.doc.lineAt(view.state.selection.asSingle().ranges[0].to).number;
+
+    if (lineNo === cursorLine) {
+      return absoluteLineNo;
+    }
+
+    return null;
+  },
+  initialSpacer: () => {
+    const spacer = new Marker('0');
+    return spacer;
+  },
+});
+
+function relativeLineNumbers(lineNo: number, state: EditorState) {
+  if (lineNo > state.doc.lines) {
+    return ' ';
+  }
+  const cursorLine = state.doc.lineAt(state.selection.asSingle().ranges[0].to).number;
+  if (lineNo === cursorLine) {
+    return ' ';
+  } else {
+    return Math.abs(cursorLine - lineNo).toString();
+  }
+}
+// This shows the numbers in the gutter
+const showLineNumbers = relativeLineNumberGutter.of(
+  lineNumbers({ formatNumber: relativeLineNumbers }),
+);
+
+// This ensures the numbers update
+// when selection (cursorActivity) happens
+const lineNumbersUpdateListener = EditorView.updateListener.of((viewUpdate: ViewUpdate) => {
+  if (viewUpdate.selectionSet) {
+    viewUpdate.view.dispatch({
+      effects: relativeLineNumberGutter.reconfigure(
+        lineNumbers({ formatNumber: relativeLineNumbers }),
+      ),
+    });
+  }
+});
+
+export function lineNumbersRelative(): Extension {
+  return [absoluteLineNumberGutter, showLineNumbers, lineNumbersUpdateListener];
+}

--- a/src/livecodes/editor/monaco/monaco.ts
+++ b/src/livecodes/editor/monaco/monaco.ts
@@ -67,7 +67,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     insertSpaces: !opt.useTabs,
     detectIndentation: false,
     tabSize: opt.tabSize,
-    lineNumbers: opt.lineNumbers ? 'on' : 'off',
+    lineNumbers: opt.lineNumbers === 'relative' ? 'relative' : opt.lineNumbers ? 'on' : 'off',
     wordWrap: opt.wordWrap ? 'on' : 'off',
     autoClosingBrackets: opt.closeBrackets ? 'always' : 'never',
     autoClosingQuotes: opt.closeBrackets ? 'always' : 'never',

--- a/src/livecodes/i18n/locales/en/translation.lokalise.json
+++ b/src/livecodes/i18n/locales/en/translation.lokalise.json
@@ -1008,6 +1008,10 @@
     "notes": "",
     "translation": "Show line numbers"
   },
+  "editorSettings.lineNumbersRelative": {
+    "notes": "",
+    "translation": "Relative line numbers *"
+  },
   "editorSettings.notAvailableInCodeJar": {
     "notes": "",
     "translation": "Not available in CodeJar"

--- a/src/livecodes/i18n/locales/en/translation.ts
+++ b/src/livecodes/i18n/locales/en/translation.ts
@@ -436,6 +436,7 @@ const translation = {
     format: 'Format',
     heading: 'Editor Settings',
     lineNumbers: 'Show line numbers',
+    lineNumbersRelative: 'Relative line numbers *',
     notAvailableInCodeJar: 'Not available in CodeJar',
     preview: 'Preview',
     semicolons: 'Format: Use Semicolons',

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -777,7 +777,7 @@ export interface EditorConfig {
    * Show line numbers in [code editor](https://livecodes.io/docs/features/editor-settings).
    * @default true
    */
-  lineNumbers: boolean;
+  lineNumbers: boolean | 'relative';
 
   /**
    * Enables word-wrap for long lines.


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ♻️ Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description

This PR allows relative line numbers in code editors (Monaco and CodeMirror).
the configuration option [`lineNumbers`](https://livecodes.io/docs/configuration/configuration-object#linenumbers) can now have any of the values: `true`, `false` or `"relative"`

This option can be set in the UI from the editor settings screen.




![image](https://github.com/user-attachments/assets/d8251ca4-916a-42a3-a357-1f0c1f669122)

![image](https://github.com/user-attachments/assets/1fefdf3a-9b74-40e3-9c48-305e4dfcbb7d)

![image](https://github.com/user-attachments/assets/b9ba9cff-e849-40ed-8e76-3eff5c469818)

Thank you @Mohmed-Refaay for the suggestion.