### PR TITLE
Fix duplicate react imports

### DIFF
--- a/src/livecodes/services/modules.ts
+++ b/src/livecodes/services/modules.ts
@@ -34,16 +34,29 @@ const ghCDNs: CDN[] = [
 export const modulesService = {
   getModuleUrl: (
     moduleName: string,
-    { isModule = true, defaultCDN = 'esm.sh' }: { isModule?: boolean; defaultCDN?: CDN } = {},
+    {
+      isModule = true,
+      defaultCDN = 'esm.sh',
+      external,
+    }: { isModule?: boolean; defaultCDN?: CDN; external?: string } = {},
   ) => {
     moduleName = moduleName.replace(/#nobundle/g, '');
 
+    const addExternalParam = (url: string) =>
+      !external || !url.includes('https://esm.sh')
+        ? url
+        : url.includes('?')
+          ? `${url}&external=${external}`
+          : `${url}?external=${external}`;
+
     const moduleUrl = getCdnUrl(moduleName, isModule, defaultCDN);
     if (moduleUrl) {
-      return moduleUrl;
+      return addExternalParam(moduleUrl);
     }
 
-    return isModule ? 'https://esm.sh/' + moduleName : 'https://cdn.jsdelivr.net/npm/' + moduleName;
+    return isModule
+      ? addExternalParam('https://esm.sh/' + moduleName)
+      : 'https://cdn.jsdelivr.net/npm/' + moduleName;
   },
 
   getUrl: (path: string, cdn?: CDN) =>

--- a/src/livecodes/templates/starter/preact-starter.ts
+++ b/src/livecodes/templates/starter/preact-starter.ts
@@ -27,7 +27,7 @@ export const preactStarter: Template = {
     content: `
 /** @jsx h */
 import { h, render } from 'preact';
-import { useSignal } from "@preact/signals?deps=preact";
+import { useSignal } from "@preact/signals";
 
 function App(props) {
   const count = useSignal(0);

--- a/src/livecodes/types/default-types.ts
+++ b/src/livecodes/types/default-types.ts
@@ -1,7 +1,4 @@
 import type { Types } from '../models';
 // eslint-disable-next-line import/no-internal-modules
-import { modulesService } from '../services/modules';
 
-export const getDefaultTypes = (): Types => ({
-  livecodes: modulesService.getUrl('livecodes/livecodes.d.ts'),
-});
+export const getDefaultTypes = (): Types => ({});


### PR DESCRIPTION
it no longer needs deps param

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ♻️ Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description

This PR fixes error when importing react libraries, where multiple instances of react were imported.

See:
https://github.com/orgs/live-codes/discussions/627
https://github.com/esm-dev/esm.sh/issues/861

When using react (jsx, tsx, react, react-tsx, etc), `react` and `react-dom` are marked as external dependencies and are explicitly added to import map 