### PR TITLE
Vue: infer props from types

### DIFF
--- a/src/livecodes/styles/app.scss
+++ b/src/livecodes/styles/app.scss
@@ -2213,11 +2213,11 @@ body {
   }
 
   #editor-container {
-    z-index: 100;
+    z-index: 45;
   }
 
   #editor-tools {
-    z-index: 200;
+    z-index: 49; // keep under monaco hover menu
   }
 
   #toolbar {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [x] ✨ Feature

## Description

This PR adds inferring Vue props from types

Demo: https://vue-infer-props-from-types.livecodes.pages.dev/?x=id/chbvz6e2ku2

## Related Tickets & Documents

#757 

