### PR TITLE
Refactor loading new projects

### DIFF
--- a/e2e/specs/sfc-processors.spec.ts
+++ b/e2e/specs/sfc-processors.spec.ts
@@ -4,6 +4,7 @@ import { getLoadedApp, waitForEditorFocus } from '../helpers';
 
 test.describe('Preprocessors', () => {
   test('in Vue', async ({ page, getTestUrl }) => {
+    test.slow();
     const sfc = `
 <template lang="pug">
 ul
@@ -32,6 +33,7 @@ li
     const { getResult, waitForResultUpdate } = await getLoadedApp(page);
 
     await waitForResultUpdate();
+    await getResult().waitForTimeout(3000);
 
     expect(await getResult().innerText(':nth-match(li, 1)')).toContain('hello world!');
     expect(await getResult().innerText(':nth-match(li, 2)')).toContain('p');

--- a/e2e/test-fixtures.ts
+++ b/e2e/test-fixtures.ts
@@ -13,6 +13,7 @@ export const test = base.extend<{
         editor,
         autoupdate: false,
         enableRestore: false,
+        recoverUnsaved: false,
         'no-defaults': true,
         closeBrackets: false,
         ...config,

--- a/src/livecodes/editor/monaco/monaco.ts
+++ b/src/livecodes/editor/monaco/monaco.ts
@@ -249,62 +249,6 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     listeners.forEach((fn) => editor.getModel()?.onDidChangeContent(fn));
   };
 
-  let modelUri = '';
-  const setModel = (
-    editor: Monaco.editor.IStandaloneCodeEditor,
-    value: string,
-    language: Language,
-  ) => {
-    const random = getRandomString();
-    const ext = getLanguageExtension(language);
-    const extension =
-      monacoMapLanguage(language) === 'typescript' && !ext?.endsWith('ts') && !ext?.endsWith('tsx')
-        ? ext + '.tsx'
-        : ext;
-    modelUri = `file:///${editorId}.${random}.${extension}`;
-    const oldModel = editor.getModel();
-    const model = monaco.editor.createModel(
-      value || '',
-      monacoMapLanguage(language),
-      monaco.Uri.parse(modelUri),
-    );
-    editor.setModel(model);
-    setTimeout(() => oldModel?.dispose(), 1000); // avoid race https://github.com/microsoft/monaco-editor/issues/1715
-    updateListeners();
-    configureTypeScriptFeatures();
-  };
-
-  const editor = monaco.editor.create(container, {
-    ...editorOptions,
-    language: monacoMapLanguage(language),
-  });
-  setModel(editor, options.value, language);
-
-  const getOrCreateModel = (value: string, lang: string | undefined, uri: Monaco.Uri) => {
-    const model = monaco.editor.getModel(uri);
-    if (model) {
-      model.setValue(value);
-      return model;
-    }
-    return monaco.editor.createModel(value, lang, uri);
-  };
-
-  const contentEditors: Array<EditorOptions['editorId']> = ['markup', 'style', 'script', 'tests'];
-  if (contentEditors.includes(editorId)) {
-    editors.push(editor);
-  }
-
-  if (editorOptions.theme === 'vs-light') container.style.backgroundColor = '#fff';
-  if (editorOptions.theme?.startsWith('http') || editorOptions.theme?.startsWith('./')) {
-    fetch(editorOptions.theme)
-      .then((res) => res.json())
-      .then((data) => {
-        monaco.editor.defineTheme('theme', data);
-        monaco.editor.setTheme('theme');
-        container.style.backgroundColor = data.colors['editor.background'];
-      });
-  }
-
   const customLanguages: Partial<Record<Language, string>> = {
     astro: baseUrl + '{{hash:monaco-lang-astro.js}}',
     clio: baseUrl + '{{hash:monaco-lang-clio.js}}',
@@ -347,6 +291,70 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
       }
     }
   };
+
+  let modelUri = '';
+  const setModel = (
+    editor: Monaco.editor.IStandaloneCodeEditor,
+    value: string,
+    language: Language,
+  ) => {
+    const random = getRandomString();
+    const ext = getLanguageExtension(language);
+    const extension =
+      monacoMapLanguage(language) === 'typescript' && !ext?.endsWith('ts') && !ext?.endsWith('tsx')
+        ? ext + '.tsx'
+        : ext;
+    modelUri = `file:///${editorId}.${random}.${extension}`;
+    const oldModel = editor.getModel();
+    const model = monaco.editor.createModel(
+      value || '',
+      monacoMapLanguage(language),
+      monaco.Uri.parse(modelUri),
+    );
+    editor.setModel(model);
+    setTimeout(() => oldModel?.dispose(), 1000); // avoid race https://github.com/microsoft/monaco-editor/issues/1715
+    updateListeners();
+    configureTypeScriptFeatures();
+  };
+
+  const editor = monaco.editor.create(container, {
+    ...editorOptions,
+    language: language.startsWith('vue') ? 'html' : monacoMapLanguage(language),
+  });
+  setModel(editor, options.value, language.startsWith('vue') ? 'html' : language);
+  loadMonacoLanguage(language);
+
+  // avoid a race condition that prevents loading vue worker
+  if (language.startsWith('vue')) {
+    setTimeout(() => {
+      setLanguage(language);
+    }, 50);
+  }
+
+  const getOrCreateModel = (value: string, lang: string | undefined, uri: Monaco.Uri) => {
+    const model = monaco.editor.getModel(uri);
+    if (model) {
+      model.setValue(value);
+      return model;
+    }
+    return monaco.editor.createModel(value, lang, uri);
+  };
+
+  const contentEditors: Array<EditorOptions['editorId']> = ['markup', 'style', 'script', 'tests'];
+  if (contentEditors.includes(editorId)) {
+    editors.push(editor);
+  }
+
+  if (editorOptions.theme === 'vs-light') container.style.backgroundColor = '#fff';
+  if (editorOptions.theme?.startsWith('http') || editorOptions.theme?.startsWith('./')) {
+    fetch(editorOptions.theme)
+      .then((res) => res.json())
+      .then((data) => {
+        monaco.editor.defineTheme('theme', data);
+        monaco.editor.setTheme('theme');
+        container.style.backgroundColor = data.colors['editor.background'];
+      });
+  }
 
   const getEditorId = () => editorId;
   const getValue = () => editor.getValue();
@@ -440,12 +448,12 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
   const setLanguage = (lang: Language, value?: string) => {
     language = lang;
     clearTypes(false);
-    const valueToIsert = value ?? editor.getValue();
+    const valueToInsert = value ?? editor.getValue();
     if (monacoMapLanguage(lang) === 'vue') {
       // avoid race condition of value changing while valor is loading
-      setValue(valueToIsert);
+      setValue(valueToInsert);
     } else {
-      setModel(editor, valueToIsert, language);
+      setModel(editor, valueToInsert, language);
     }
     loadMonacoLanguage(lang).then(() => {
       if (monacoMapLanguage(lang) === 'vue') {

--- a/src/livecodes/toolspane/tools.ts
+++ b/src/livecodes/toolspane/tools.ts
@@ -93,7 +93,7 @@ export const createToolsPane = (
 
   const setHidden = (hide: boolean) => {
     if (hide) {
-      toolsSplit.collapse(1);
+      toolsSplit.setSizes(sizes.none);
       result.style.minHeight = '100%';
     } else {
       result.style.minHeight = 'unset';
@@ -162,7 +162,7 @@ export const createToolsPane = (
 
   const open = (toolId: number, maximize = false) => {
     if (maximize) {
-      toolsSplit.collapse(0);
+      toolsSplit.setSizes(sizes.full);
       status = 'full';
     } else {
       toolsSplit.setSizes(sizes.open);
@@ -173,7 +173,7 @@ export const createToolsPane = (
   };
 
   const close = () => {
-    toolsSplit.collapse(1);
+    toolsSplit.setSizes(sizes.closed);
     status = 'closed';
     sizeChanged();
     tools.forEach((tool) => tool.onDeactivate());


### PR DESCRIPTION
This PR refactors applying new config when loading new projects.

This is mainly done by merging the functions `bootstrap` and `applyConfig` while removing redunduncies.

In addition a fix was provided for a race condition preventing monaco vue worker from loading.