### PR TITLE
Improve loading

### DIFF
--- a/e2e/specs/sdk-options.spec.ts
+++ b/e2e/specs/sdk-options.spec.ts
@@ -1,0 +1,120 @@
+import { expect } from '@playwright/test';
+import { compressToEncodedURIComponent } from 'lz-string';
+import { getPlaygroundUrl, type Config, type EmbedOptions } from '../../src/sdk/index';
+import { getLoadedApp, waitForEditorFocus } from '../helpers';
+import { test } from '../test-fixtures';
+
+test.describe('SDK options', () => {
+  test('params', async ({ page, getTestUrl }) => {
+    const params: EmbedOptions['params'] = {
+      md: `# Hello, World!`,
+      css: `h1 { color: red; }`,
+    };
+
+    const url = getPlaygroundUrl({ appUrl: getTestUrl(), params });
+    await page.goto(url);
+
+    const { app, getResult, waitForResultUpdate } = await getLoadedApp(page);
+
+    await waitForEditorFocus(app);
+    await waitForResultUpdate();
+
+    const titleText = await getResult().innerText('h1');
+    expect(titleText).toBe('Hello, World!');
+    expect(await getResult().$eval('h1', (e) => getComputedStyle(e).color)).toBe('rgb(255, 0, 0)');
+  });
+
+  test('config', async ({ page, getTestUrl }) => {
+    const config: Partial<Config> = {
+      markup: {
+        language: 'markdown',
+        content: `# Hello, World!`,
+      },
+      style: {
+        language: 'css',
+        content: `h1 { color: red; }`,
+      },
+    };
+
+    const url = getPlaygroundUrl({ appUrl: getTestUrl(), config });
+    await page.goto(url);
+
+    const { app, getResult, waitForResultUpdate } = await getLoadedApp(page);
+
+    await waitForEditorFocus(app);
+    await waitForResultUpdate();
+
+    const titleText = await getResult().innerText('h1');
+    expect(titleText).toBe('Hello, World!');
+    expect(await getResult().$eval('h1', (e) => getComputedStyle(e).color)).toBe('rgb(255, 0, 0)');
+  });
+
+  test('template', async ({ page, getTestUrl }) => {
+    const url = getPlaygroundUrl({ appUrl: getTestUrl(), template: 'typescript' });
+    await page.goto(url);
+
+    const { app, getResult, waitForResultUpdate } = await getLoadedApp(page);
+
+    await waitForEditorFocus(app);
+    await waitForResultUpdate();
+
+    const titleText = await getResult().innerText('h1');
+    expect(titleText).toBe('Hello, TypeScript!');
+  });
+
+  test('import', async ({ page, getTestUrl }) => {
+    const url = getPlaygroundUrl({
+      appUrl: getTestUrl(),
+      import: 'https://hatemhosny.github.io/typescript-demo-for-testing-import-/',
+    });
+    await page.goto(url);
+
+    const { app, getResult, waitForResultUpdate } = await getLoadedApp(page);
+
+    await waitForEditorFocus(app);
+    await waitForResultUpdate();
+
+    const titleText = await getResult().innerText('h1');
+    expect(titleText).toBe('Hello, World!');
+  });
+
+  test('options override: template -> import -> config -> params', async ({ page, getTestUrl }) => {
+    const url = getPlaygroundUrl({
+      appUrl: getTestUrl(),
+      template: 'react',
+      import:
+        'code/' +
+        compressToEncodedURIComponent(
+          JSON.stringify({
+            style: {
+              language: 'css',
+              content: `h1 { color: green; }`,
+            },
+            stylesheets: ['data:text/css,h2 { color: blue; }'],
+          }),
+        ),
+      config: {
+        markup: {
+          language: 'markdown',
+          content: `## Hello, from config!`,
+        },
+      },
+      params: {
+        css: `h1 { color: red; }`,
+      },
+    });
+    await page.goto(url);
+
+    const { app, getResult, waitForResultUpdate } = await getLoadedApp(page);
+
+    await waitForEditorFocus(app);
+    await waitForResultUpdate();
+
+    const h1 = await getResult().innerText('h1');
+    expect(h1).toBe('Hello, React!');
+    const h2 = await getResult().innerText('h2');
+    expect(h2).toBe('Hello, from config!');
+    expect(await getResult().$eval('h1', (e) => getComputedStyle(e).color)).toBe('rgb(255, 0, 0)');
+    expect(await getResult().$eval('h2', (e) => getComputedStyle(e).color)).toBe('rgb(0, 0, 255)');
+  });
+});

--- a/src/livecodes/UI/create-language-menus.ts
+++ b/src/livecodes/UI/create-language-menus.ts
@@ -17,7 +17,7 @@ export const createLanguageMenus = (
   eventsManager: EventsManager,
   showLanguageInfo: (languageInfo: HTMLElement) => void,
   loadStarterTemplate: (templateName: Template['name']) => void,
-  importCode: (options: { url: string }) => Promise<boolean>,
+  importCode: (options: { importUrl: string }) => Promise<boolean>,
   registerMenuButton: (menu: HTMLElement, button: HTMLElement) => void,
 ) => {
   const editorIds: EditorId[] = ['markup', 'style', 'script'];
@@ -143,7 +143,7 @@ export const createLanguageMenus = (
                 'click',
                 async (event) => {
                   event.preventDefault();
-                  importCode({ url: codeUrl });
+                  importCode({ importUrl: codeUrl });
                 },
                 false,
               );

--- a/src/livecodes/config/build-config.ts
+++ b/src/livecodes/config/build-config.ts
@@ -140,6 +140,7 @@ export const getParams = (
     if (params[key] === 'true') params[key] = true;
     if (params[key] === 'false') params[key] = false;
   });
+  params.x ??= params.import;
   return params;
 };
 

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -1,28 +1,31 @@
 import { getPlaygroundUrl } from '../sdk';
-import { createCustomEditors, createEditor, getFontFamily } from './editor';
 import {
-  getLanguageByAlias,
-  getLanguageCompiler,
-  getLanguageEditorId,
-  getLanguageExtension,
-  getLanguageSpecs,
-  getLanguageTitle,
-  languageIsEnabled,
-  languages,
-  mapLanguage,
-  processorIsEnabled,
-  processors,
-} from './languages';
-import {
-  createStores,
-  fakeStorage,
-  initializeStores,
-  type StorageItem,
-  type Stores,
-} from './storage';
-
+  createLoginContainer,
+  createOpenItem,
+  createProjectInfoUI,
+  createSplitPanes,
+  createStarterTemplateLink,
+  createTemplatesContainer,
+  displayLoggedIn,
+  displayLoggedOut,
+  getFullscreenButton,
+  getResultElement,
+  loadingMessage,
+  noUserTemplates,
+} from './UI';
+import type {
+  BroadcastData,
+  BroadcastInfo,
+  BroadcastResponseData,
+  BroadcastResponseError,
+} from './UI/broadcast';
+import { getCommandMenuActions } from './UI/command-menu-actions';
+import { createLanguageMenus, createProcessorItem } from './UI/create-language-menus';
+import { createModal } from './UI/modal';
+import * as UI from './UI/selectors';
+import { themeColors } from './UI/theme-colors';
 import { cacheIsValid, getCache, getCachedCode, setCache, updateCache } from './cache';
-import { cjs2esm, getAllCompilers, getCompiler, getCompileResult } from './compiler';
+import { cjs2esm, getAllCompilers, getCompileResult, getCompiler } from './compiler';
 import {
   buildConfig,
   defaultConfig,
@@ -35,6 +38,7 @@ import {
   setConfig,
   upgradeAndValidate,
 } from './config';
+import { createCustomEditors, createEditor, getFontFamily } from './editor';
 import { hasJsx } from './editor/ts-compiler-options';
 import { createEventsManager, createPub } from './events';
 import { customEvents } from './events/custom-events';
@@ -63,8 +67,22 @@ import type {
 } from './i18n';
 import { appLanguages } from './i18n/app-languages';
 import { isGithub } from './import/check-src';
+import { importCompressedCode } from './import/code';
 import { importFromFiles } from './import/files';
 import { populateConfig } from './import/utils';
+import {
+  getLanguageByAlias,
+  getLanguageCompiler,
+  getLanguageEditorId,
+  getLanguageExtension,
+  getLanguageSpecs,
+  getLanguageTitle,
+  languageIsEnabled,
+  languages,
+  mapLanguage,
+  processorIsEnabled,
+  processors,
+} from './languages';
 import type {
   API,
   APICommands,
@@ -91,8 +109,8 @@ import type {
   Modal,
   Notifications,
   Processor,
-  Screen,
   SDKEvent,
+  Screen,
   ShareData,
   Template,
   TestResult,
@@ -108,34 +126,16 @@ import { cleanResultFromDev, createResultPage } from './result';
 import { createAuthService, getAppCDN, sandboxService, shareService } from './services';
 import type { GitHubFile } from './services/github';
 import { permanentUrlService } from './services/permanent-url';
+import {
+  createStores,
+  fakeStorage,
+  initializeStores,
+  type StorageItem,
+  type Stores,
+} from './storage';
 import { getStarterTemplates, getTemplate } from './templates';
 import { createToolsPane } from './toolspane';
 import { createTypeLoader, getDefaultTypes } from './types';
-import {
-  createLoginContainer,
-  createOpenItem,
-  createProjectInfoUI,
-  createSplitPanes,
-  createStarterTemplateLink,
-  createTemplatesContainer,
-  displayLoggedIn,
-  displayLoggedOut,
-  getFullscreenButton,
-  getResultElement,
-  loadingMessage,
-  noUserTemplates,
-} from './UI';
-import type {
-  BroadcastData,
-  BroadcastInfo,
-  BroadcastResponseData,
-  BroadcastResponseError,
-} from './UI/broadcast';
-import { getCommandMenuActions } from './UI/command-menu-actions';
-import { createLanguageMenus, createProcessorItem } from './UI/create-language-menus';
-import { createModal } from './UI/modal';
-import * as UI from './UI/selectors';
-import { themeColors } from './UI/theme-colors';
 import {
   capitalize,
   colorToHex,
@@ -149,8 +149,8 @@ import {
   loadStylesheet,
   predefinedValues,
   safeName,
-  stringify,
   stringToValidJson,
+  stringify,
   toDataUrl,
 } from './utils';
 import {
@@ -165,8 +165,6 @@ import {
   ninjaKeysUrl,
   snackbarUrl,
 } from './vendors';
-
-import { importCompressedCode } from './import/code';
 
 // declare global dependencies
 declare global {

--- a/src/livecodes/import/code.ts
+++ b/src/livecodes/import/code.ts
@@ -1,8 +1,10 @@
 import type { Config } from '../models';
 import { decompress } from '../utils/compression';
+import { isCompressedCode } from './check-src';
 
 export const importCompressedCode = (url: string) => {
-  const code = url.slice(5);
+  if (!isCompressedCode(url)) return {};
+  const code = url.slice('code/'.length);
   let config: Partial<Config>;
   try {
     config = JSON.parse(decompress(code) || '{}');


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] ♻️ Code Refactor
- [x] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description

This PR improves loading new projects.

A project config can be generated from a variety of sources. Some of the sources are already available when loading (e.g. SDK config, params, compressed code in `x` param, etc), while others need to be imported (e.g. template, import URL, config content URL, etc)

These sources were mixed in [`importExternalContent`](https://github.com/live-codes/livecodes/blob/ed4c7f24cece43c6218184c581ce2e621e8262df/src/livecodes/core.ts#L5241). So, [`initializePlayground`](https://github.com/live-codes/livecodes/blob/ed4c7f24cece43c6218184c581ce2e621e8262df/src/livecodes/core.ts#L5415) started loading the UI then followed by a flash of changing content when `importExternalContent` runs.
In addition, a notification of "Loading Content" appeared even when the content was already available.

This PR now handles all already available sources in the initial load and keeps only remote content to `importExternalContent`.

@BassemHalim whould you please review this, which is very much related to your PR #819 



