### PR TITLE
add bundle size workflow

### DIFF
--- a/.bundlewatch.config.js
+++ b/.bundlewatch.config.js
@@ -12,18 +12,18 @@ module.exports = {
       path: './build/livecodes/*(app|embed|headless).*.js',
       maxSize: '120kB',
     },
-    // {
-    //   path: './build/livecodes/lang-*.js',
-    //   maxSize: '10kB',
-    // },
+    {
+      path: './build/livecodes/lang-*.js',
+      maxSize: '20kB',
+    },
     {
       path: './build/livecodes/*.css',
       maxSize: '25kB',
     },
-    // {
-    //   path: './build/livecodes/i18n-*.json',
-    //   maxSize: '10kB',
-    // },
+    {
+      path: './build/livecodes/i18n-*.json',
+      maxSize: '15kB',
+    },
   ],
   defaultCompression: 'brotli',
   normalizeFilenames: /^.+?((\.[^.]{8,}}?)|())\.\w+$/,

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: preactjs/compressed-size-action@v2
         with:
           build-script: 'build:app'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -13,5 +13,5 @@ jobs:
           build-script: 'build:app'
           pattern: './build/**/*.{js,css,html,json}'
           strip-hash: "\\b\\w{32}\\."
-          minimum-change-threshold: 100
+          minimum-change-threshold: 150
           compression: 'brotli'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,17 @@
+name: Bundle Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          build-script: 'build:app'
+          pattern: './build/**/*.{js,css,html,json}'
+          strip-hash: "\\b\\w{32}\\."
+          minimum-change-threshold: 100
+          compression: 'brotli'


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ♻️ Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description

This adds a bundle size CI workflow, using [compressed-size-action](https://github.com/preactjs/compressed-size-action).

Bundle-watch remote service stopped working. Size difference is no longer reported.