### PR TITLE
add `languages` and `processors` to `window.deps` and avoid repeated imports

### DIFF
--- a/.jest/setup.js
+++ b/.jest/setup.js
@@ -1,1 +1,0 @@
-process.env.VERSION = require('../package.json').appVersion;

--- a/.jest/setup.ts
+++ b/.jest/setup.ts
@@ -1,0 +1,6 @@
+import pkg from '../package.json';
+import { languages } from '../src/livecodes/languages/languages';
+import { processors } from '../src/livecodes/languages/processors';
+
+process.env.VERSION = pkg.appVersion;
+(window as any).deps = { languages, processors };

--- a/package.json
+++ b/package.json
@@ -161,9 +161,10 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",
-    "setupFiles": ["<rootDir>/.jest/setup.js"],
+    "setupFiles": ["<rootDir>/.jest/setup.ts"],
     "testPathIgnorePatterns": ["/node_modules/", "/build/", "/src/modules/"],
     "collectCoverageFrom": ["src/**/*.ts", "!**/build/**", "!**/vendor/**", "!src/modules/**"],
-    "coverageReporters": ["json", "html", "lcov"]
+    "coverageReporters": ["json", "html", "lcov"],
+    "resolveJsonModule": true
   }
 }

--- a/src/livecodes/UI/command-menu-actions.ts
+++ b/src/livecodes/UI/command-menu-actions.ts
@@ -1,5 +1,5 @@
 import { appLanguages } from '../i18n/app-languages';
-import { languageIsEnabled, languages, processorIsEnabled, processors } from '../languages';
+import { languageIsEnabled, processorIsEnabled } from '../languages';
 import type { Config, INinjaAction, Screen, TemplateName } from '../models';
 import { isMac, predefinedValues, stringUnionToArray } from '../utils/utils';
 import * as UI from './selectors';
@@ -206,7 +206,7 @@ export const getCommandMenuActions = ({
       title: window.deps.translateString('commandMenu.selectLanguage', 'Select Language'),
       content: getContent('Select Language'),
       mdIcon: 'code',
-      children: languages
+      children: window.deps.languages
         .filter((l) => languageIsEnabled(l.name, getConfig()))
         .sort((a, b) => a.title.localeCompare(b.title))
         .map((lang) => ({
@@ -226,7 +226,7 @@ export const getCommandMenuActions = ({
       content: getContent('Processors'),
       // mdIcon: 'manufacturing',
       icon: icons.manufacturing,
-      children: processors
+      children: window.deps.processors
         .filter((p) => !p.hidden && processorIsEnabled(p.name, getConfig()))
         .map((processor) => ({
           id: 'Processor: ' + processor.title,

--- a/src/livecodes/UI/create-language-menus.ts
+++ b/src/livecodes/UI/create-language-menus.ts
@@ -1,5 +1,3 @@
-import { languages } from '../languages/languages';
-import { processors } from '../languages/processors';
 import { languageIsEnabled, processorIsEnabled } from '../languages/utils';
 import type {
   Config,
@@ -56,7 +54,7 @@ export const createLanguageMenus = (
     languageMenu.classList.add('dropdown-menu-' + editorId);
     menuScroller.appendChild(languageMenu);
 
-    const editorLanguages = [...languages]
+    const editorLanguages = [...window.deps.languages]
       .filter((language) => language.editor === editorId)
       .filter((language) => languageIsEnabled(language.name, config));
 
@@ -71,7 +69,7 @@ export const createLanguageMenus = (
       }
     }
 
-    const enabledProcessors = processors.filter(
+    const enabledProcessors = window.deps.processors.filter(
       (p) => p.editor === editorId && processorIsEnabled(p.name, config),
     );
     const processorsHeader =

--- a/src/livecodes/UI/snippets.ts
+++ b/src/livecodes/UI/snippets.ts
@@ -1,5 +1,5 @@
 import { addSnippetScreen, snippetsScreen } from '../html';
-import { getLanguageTitle, languages } from '../languages';
+import { getLanguageTitle } from '../languages/utils';
 import type {
   AppData,
   CodeEditor,
@@ -11,7 +11,8 @@ import type {
   Screen,
   Snippet,
 } from '../models';
-import { generateId, type Storage } from '../storage';
+import type { Storage } from '../storage/models';
+import { generateId } from '../storage/storage';
 import { copy as copyIcon, iconDelete as deleteIcon, edit as editIcon } from '../UI/icons';
 import { copyToClipboard, isMobile, loadScript } from '../utils';
 import { flexSearchUrl } from '../vendors';
@@ -527,7 +528,7 @@ export const createAddSnippetContainer = async ({
   const selectedLanguage =
     loadedSnippet?.language || deps.getAppData()?.snippets?.language || 'javascript';
 
-  [...languages, textLanguage]
+  [...window.deps.languages, textLanguage]
     .filter(
       (lang) =>
         ['jsx', 'tsx', 'rescript', 'reason', 'ocaml'].includes(lang.name) ||

--- a/src/livecodes/compiler/compile-blocks.ts
+++ b/src/livecodes/compiler/compile-blocks.ts
@@ -3,8 +3,7 @@ import {
   getLanguageEditorId,
   processorIsActivated,
   processorIsEnabled,
-  processors,
-} from '../languages';
+} from '../languages/utils';
 import type { CompileInfo, Config } from '../models';
 import { modulesService } from '../services/modules';
 import { getFileExtension } from '../utils/utils';
@@ -88,7 +87,7 @@ const postProcess = async (content: string, config: Config, language: LanguageOr
     postcssRequired = true;
   }
 
-  for (const processor of processors) {
+  for (const processor of window.deps.processors) {
     if (
       (processorIsEnabled(processor.name, config) &&
         processorIsActivated(processor.name, config) &&

--- a/src/livecodes/compiler/compile.worker.ts
+++ b/src/livecodes/compiler/compile.worker.ts
@@ -24,6 +24,7 @@ const worker: Worker & {
   CodemirrorTsWorker?: any;
 } = self as any;
 (self as any).window = self;
+(self as any).deps = { languages, processors };
 
 const loadLanguageCompiler = async (
   language: LanguageOrProcessor,

--- a/src/livecodes/compiler/create-compiler.ts
+++ b/src/livecodes/compiler/create-compiler.ts
@@ -2,10 +2,8 @@ import {
   getActivatedProcessors,
   getCustomSettings,
   getLanguageEditorId,
-  languages,
   processorIsActivated,
   processorIsEnabled,
-  processors,
 } from '../languages';
 import type {
   CompileInfo,
@@ -48,7 +46,11 @@ export const createCompiler = async ({
 
   const initialize = async () =>
     new Promise(async (resolve) => {
-      compilers = getAllCompilers([...languages, ...processors], config, baseUrl);
+      compilers = getAllCompilers(
+        [...window.deps.languages, ...window.deps.processors],
+        config,
+        baseUrl,
+      );
       const compilerUrl = sandboxService.getCompilerUrl() + '?appCDN=' + getAppCDN();
       compilerSandbox = await createCompilerSandbox(compilerUrl);
 
@@ -250,7 +252,7 @@ export const createCompiler = async ({
       postcssRequired = true;
     }
 
-    for (const processor of processors) {
+    for (const processor of window.deps.processors) {
       if (
         (processorIsEnabled(processor.name, config) &&
           processorIsActivated(processor.name, config) &&

--- a/src/livecodes/compiler/get-all-compilers.ts
+++ b/src/livecodes/compiler/get-all-compilers.ts
@@ -1,4 +1,4 @@
-import { languageIsEnabled, processors } from '../languages';
+import { languageIsEnabled } from '../languages';
 import type {
   Compiler,
   Compilers,
@@ -17,7 +17,7 @@ export const getAllCompilers = (
   languages
     .filter(
       (language) =>
-        processors.includes(language as ProcessorSpecs) ||
+        window.deps.processors.includes(language as ProcessorSpecs) ||
         languageIsEnabled((language as LanguageSpecs).name, config),
     )
     .reduce((compilers, language) => {

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -183,6 +183,8 @@ declare global {
         value: I18nValueType<Key, Value>,
         ...args: I18nInterpolationType<I18nValueType<Key, Value>>
       ) => string;
+      languages: typeof languages;
+      processors: typeof processors;
     };
   }
 }
@@ -5700,6 +5702,8 @@ const initApp = async (config: Partial<Config>, baseUrl: string) => {
   window.deps = {
     showMode,
     translateString: translateStringMock,
+    languages,
+    processors,
   };
   await initializePlayground({ config, baseUrl }, async () => {
     basicHandlers();
@@ -5713,6 +5717,8 @@ const initEmbed = async (config: Partial<Config>, baseUrl: string) => {
   window.deps = {
     showMode,
     translateString: translateStringMock,
+    languages,
+    processors,
   };
   await initializePlayground({ config, baseUrl, isEmbed: true }, async () => {
     basicHandlers();
@@ -5727,6 +5733,8 @@ const initHeadless = async (config: Partial<Config>, baseUrl: string) => {
   window.deps = {
     showMode: () => undefined,
     translateString: translateStringMock,
+    languages,
+    processors,
   };
   await initializePlayground({ config, baseUrl, isEmbed: true, isHeadless: true }, () => {
     notifications = {

--- a/src/livecodes/import/dom.ts
+++ b/src/livecodes/import/dom.ts
@@ -1,4 +1,4 @@
-import { getLanguageByAlias, getLanguageEditorId, languages } from '../languages';
+import { getLanguageByAlias, getLanguageEditorId } from '../languages';
 import type { Config, EditorId, Language } from '../models';
 import { decodeHTML } from '../utils';
 
@@ -50,7 +50,7 @@ export const importFromDom = async (
   const dom = domparser.parseFromString(html, 'text/html');
   const activeEditor = config.activeEditor;
 
-  const defaultParams = languages
+  const defaultParams = window.deps.languages
     .map((lang) => lang.name)
     .reduce(
       (acc, langName) => ({

--- a/src/livecodes/import/image.ts
+++ b/src/livecodes/import/image.ts
@@ -1,4 +1,4 @@
-import { detectLanguage, getLanguageByAlias, getLanguageEditorId, languages } from '../languages';
+import { detectLanguage, getLanguageByAlias, getLanguageEditorId } from '../languages';
 import type { ContentConfig } from '../models';
 import { blobToBase64, loadScript } from '../utils/utils';
 import { metaPngUrl, tesseractUrl } from '../vendors';
@@ -109,12 +109,12 @@ export const importFromImage = async (blob: Blob): Promise<Partial<ContentConfig
     }
 
     if (content.trim().length > 3) {
-      const langs = languages.map((lang) => lang.name);
+      const langs = window.deps.languages.map((lang) => lang.name);
       const detected = await detectLanguage(content, langs);
       detected.language = getLanguageByAlias(detected.language) || detected.language;
       detected.secondBest = getLanguageByAlias(detected.secondBest) || detected.secondBest;
       // language name or filename with extension in image
-      const langNamesInCode = languages
+      const langNamesInCode = window.deps.languages
         .filter(
           (lang) =>
             content.search(new RegExp(`\\b${lang.name}\\b`, 'i')) !== -1 ||

--- a/src/livecodes/import/project-id.ts
+++ b/src/livecodes/import/project-id.ts
@@ -1,4 +1,4 @@
-import { shareService } from '../services';
+import { shareService } from '../services/share';
 
 export const importProject = (url: string) => {
   const id = url.slice('id/'.length);

--- a/src/livecodes/import/utils.ts
+++ b/src/livecodes/import/utils.ts
@@ -1,4 +1,4 @@
-import { getLanguageByAlias, getLanguageEditorId, languages } from '../languages';
+import { getLanguageByAlias, getLanguageEditorId } from '../languages';
 import type { Config, EditorId, Language } from '../models';
 
 export interface SourceFile {
@@ -130,8 +130,8 @@ export const populateConfig = (
       }
       return (
         // then sort by language
-        languages.findIndex((language) => language.name === a.language) -
-        languages.findIndex((language) => language.name === b.language)
+        window.deps.languages.findIndex((language) => language.name === a.language) -
+        window.deps.languages.findIndex((language) => language.name === b.language)
       );
     })
     .reduce((output: Partial<Config>, file) => {

--- a/src/livecodes/languages/malina/lang-malina-compiler.ts
+++ b/src/livecodes/languages/malina/lang-malina-compiler.ts
@@ -1,4 +1,4 @@
-import { compileAllBlocks } from '../../compiler';
+import { compileAllBlocks } from '../../compiler/compile-blocks';
 import type { CompilerFunction } from '../../models';
 import { getLanguageCustomSettings } from '../../utils';
 import { acornUrl, astringUrl, cjs2esUrl, csstreeUrl, malinaBaseUrl } from '../../vendors';

--- a/src/livecodes/languages/postcss/processor-postcss-compiler.ts
+++ b/src/livecodes/languages/postcss/processor-postcss-compiler.ts
@@ -1,4 +1,4 @@
-import { replaceStyleImports } from '../../compiler';
+import { replaceStyleImports } from '../../compiler/import-map';
 import type {
   CompileOptions,
   CompilerFunction,
@@ -7,10 +7,10 @@ import type {
   ProcessorSpecs,
 } from '../../models';
 import { escapeCode, getAbsoluteUrl } from '../../utils';
-import { processors } from '../processors';
 import { processorIsEnabled } from '../utils';
 
-const getSpecs = (pluginName: Processor) => processors.find((specs) => specs.name === pluginName);
+const getSpecs = (pluginName: Processor) =>
+  window.deps.processors.find((specs) => specs.name === pluginName);
 
 (self as any).createPostcssCompiler = (): CompilerFunction => {
   const postCssOptions = { from: undefined };
@@ -34,13 +34,13 @@ const getSpecs = (pluginName: Processor) => processors.find((specs) => specs.nam
     const configPlugins = config.processors.filter((p) => getSpecs(p)?.isPostcssPlugin);
     const isEnabled = (pluginName: Processor) =>
       processorIsEnabled(pluginName, config) && configPlugins.includes(pluginName);
-    return processors.map((plugin) => plugin.name).filter(isEnabled);
+    return window.deps.processors.map((plugin) => plugin.name).filter(isEnabled);
   };
 
   const getPlugins = (config: Config, baseUrl: string, options: CompileOptions) => {
     const pluginNames = getEnabledPluginNames(config);
     pluginNames.forEach((pluginName) => loadPlugin(pluginName, baseUrl));
-    return processors
+    return window.deps.processors
       .filter((specs) => pluginNames.includes(specs.name))
       .map((specs) => loadedPlugins[specs.name]?.(config, baseUrl, options))
       .flat(); // allow plugins to have arrays of plugins

--- a/src/livecodes/languages/riot/lang-riot-compiler.ts
+++ b/src/livecodes/languages/riot/lang-riot-compiler.ts
@@ -1,6 +1,6 @@
-import { compileAllBlocks } from '../../compiler';
+import { compileAllBlocks } from '../../compiler/compile-blocks';
 import type { CompilerFunction } from '../../models';
-import { getLanguageCustomSettings } from '../../utils';
+import { getLanguageCustomSettings } from '../../utils/utils';
 
 (self as any).createRiotCompiler =
   (): CompilerFunction =>

--- a/src/livecodes/languages/svelte/lang-svelte-compiler.ts
+++ b/src/livecodes/languages/svelte/lang-svelte-compiler.ts
@@ -1,6 +1,6 @@
-import { getCompileResult } from '../../compiler';
 import { compileAllBlocks } from '../../compiler/compile-blocks';
 import { createImportMap, replaceSFCImports } from '../../compiler/import-map';
+import { getCompileResult } from '../../compiler/utils';
 import type { CompilerFunction, Config, Language } from '../../models';
 import { getLanguageByAlias, getLanguageCustomSettings } from '../utils';
 

--- a/src/livecodes/languages/tailwindcss/processor-tailwindcss-compiler.ts
+++ b/src/livecodes/languages/tailwindcss/processor-tailwindcss-compiler.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-bitwise */
-import { compileInCompiler, isBare, replaceStyleImports } from '../../compiler';
+import { compileInCompiler } from '../../compiler/compile-in-compiler';
+import { isBare, replaceStyleImports } from '../../compiler/import-map';
 import type { CompilerFunction, Config, Language } from '../../models';
 import { modulesService } from '../../services';
 import { getLanguageCustomSettings } from '../../utils/utils';

--- a/src/livecodes/languages/utils.ts
+++ b/src/livecodes/languages/utils.ts
@@ -1,13 +1,11 @@
 import type { Compiler, Config, CustomSettings, Language, Processor } from '../models';
 import { getLanguageCustomSettings } from '../utils/utils';
 import { highlightjsUrl } from '../vendors';
-import { languages } from './languages';
-import { processors } from './processors';
 
 export const getLanguageByAlias = (alias: string = ''): Language | undefined => {
   if (!alias) return;
   const aliasLowerCase = alias?.toLowerCase();
-  return languages.find(
+  return window.deps.languages.find(
     (language) =>
       language.name === aliasLowerCase ||
       language.title.toLowerCase() === aliasLowerCase ||
@@ -16,18 +14,18 @@ export const getLanguageByAlias = (alias: string = ''): Language | undefined => 
 };
 
 export const getLanguageTitle = (language: Language) => {
-  const languageSpecs = languages.find((lang) => lang.name === language);
+  const languageSpecs = window.deps.languages.find((lang) => lang.name === language);
   return languageSpecs?.longTitle || languageSpecs?.title || language.toUpperCase();
 };
 
 export const getLanguageEditorId = (alias: string = '') =>
-  languages.find((lang) => lang.name === getLanguageByAlias(alias))?.editor;
+  window.deps.languages.find((lang) => lang.name === getLanguageByAlias(alias))?.editor;
 
 export const getLanguageExtension = (alias: string = '') =>
-  languages.find((lang) => lang.name === getLanguageByAlias(alias))?.extensions[0];
+  window.deps.languages.find((lang) => lang.name === getLanguageByAlias(alias))?.extensions[0];
 
 export const getLanguageSpecs = (alias: string = '') =>
-  languages.find((lang) => lang.name === getLanguageByAlias(alias));
+  window.deps.languages.find((lang) => lang.name === getLanguageByAlias(alias));
 
 export const getLanguageCompiler = (alias: string = ''): Compiler | undefined => {
   const languageSpecs = getLanguageSpecs(alias);
@@ -55,7 +53,7 @@ export const languageIsEnabled = (language: Language, config: Config) => {
 };
 
 export const processorIsEnabled = (processor: Processor, config: Config) => {
-  if (!processors.map((p) => p.name).includes(processor)) return false;
+  if (!window.deps.processors.map((p) => p.name).includes(processor)) return false;
   if (!config.languages) return true;
   return config.languages.includes(processor);
 };
@@ -70,7 +68,7 @@ export const processorIsActivated = (processor: Processor, config: Config) =>
 export const getActivatedProcessors = (language: Language, config: Config) => {
   const editorId = getLanguageEditorId(language);
   if (!editorId) return '';
-  return processors
+  return window.deps.processors
     .filter((p) => p.editor === editorId)
     .map((p) => p.name)
     .filter((p) => processorIsEnabled(p, config))

--- a/src/livecodes/toolspane/compiled-code-viewer.ts
+++ b/src/livecodes/toolspane/compiled-code-viewer.ts
@@ -1,6 +1,6 @@
 import { getEditorConfig } from '../config';
 import { createEditor, getFontFamily } from '../editor';
-import { getLanguageExtension, languages, mapLanguage } from '../languages';
+import { getLanguageExtension, mapLanguage } from '../languages';
 import type {
   CodeEditor,
   CompiledCodeViewer,
@@ -91,7 +91,7 @@ export const createCompiledCodeViewer = (
     }
     fixTypes(language, content);
     if (languageLabel) {
-      const compiledLanguage = languages.find((lang) => lang.name === label);
+      const compiledLanguage = window.deps.languages.find((lang) => lang.name === label);
       const title = compiledLanguage?.longTitle || compiledLanguage?.title || label || '';
       languageLabel.innerHTML = title;
     }

--- a/storybook/src/deps.ts
+++ b/storybook/src/deps.ts
@@ -1,13 +1,20 @@
+import { languages } from '../../src/livecodes/languages/languages';
+import { processors } from '../../src/livecodes/languages/processors';
+
 declare global {
   interface Window {
     deps: {
       translateString: (key: string, value: string) => string;
+      languages: typeof languages;
+      processors: typeof processors;
     };
   }
 }
 
 window.deps = {
   translateString: (_key: string, value: string) => value,
+  languages,
+  processors,
 };
 
 export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "allowUmdGlobalAccess": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
+    "resolveJsonModule": true,
 
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] ♻️ Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description

add `languages` and `processors` to `window.deps` and avoid repeated imports

## Related Tickets & Documents

Closes #840

