### PR TITLE
Config improvements

### DIFF
--- a/docs/docs/configuration/query-params.mdx
+++ b/docs/docs/configuration/query-params.mdx
@@ -91,7 +91,19 @@ https://livecodes.io?js=console.log('Hello World!')&console=open
   Example:
 
   ```
-  ?languages=html,md,css,ts
+  ?processors=tailwindcss,autoprefixer
+  ```
+
+- Custom Settings can be set like this:
+
+  ```
+  ?customSettings={template:{prerender:false}}
+  ```
+
+  or this:
+
+  ```
+  ?customSettings.template.prerender=false
   ```
 
 - Values set in the URL query parameters override those set in [configuration object](./configuration-object.mdx).
@@ -160,4 +172,4 @@ https://livecodes.io?js=console.log('Hello World!')&console=open
 For usage examples, check [storybook](pathname:///../stories/?path=/story/embed-options-params--select-language) and [unit tests](https://github.com/live-codes/livecodes/blob/develop/src/livecodes/config/__tests__/build-config.spec.ts).
 :::
 
-<!-- TODO: add docs for languageSelector and ToolsStatus -->
+{/* TODO: add docs for languageSelector and ToolsStatus */}

--- a/src/livecodes/config/__tests__/build-config.spec.ts
+++ b/src/livecodes/config/__tests__/build-config.spec.ts
@@ -197,6 +197,20 @@ describe('loadParamConfig', () => {
     expect(output.activeEditor).toEqual('style');
   });
 
+  test('?processors=tailwindcss,autoprefixer', () => {
+    const output: Partial<Config> = loadParamConfig(defaultConfig, {
+      processors: 'tailwindcss,autoprefixer',
+    });
+    expect(output.processors).toEqual(['tailwindcss', 'autoprefixer']);
+  });
+
+  test('?processors= tailwindcss, autoprefixer', () => {
+    const output: Partial<Config> = loadParamConfig(defaultConfig, {
+      processors: ' tailwindcss, autoprefixer',
+    });
+    expect(output.processors).toEqual(['tailwindcss', 'autoprefixer']);
+  });
+
   test('?tags=js,advanced,proof-of-concept', () => {
     const output: Partial<Config> = loadParamConfig(defaultConfig, {
       tags: 'js,advanced,proof-of-concept',
@@ -475,5 +489,19 @@ describe('loadParamConfig', () => {
       active: '',
       status: 'open',
     });
+  });
+
+  test('?customSettings={template:{prerender:false}}', () => {
+    const output: Partial<Config> = loadParamConfig(defaultConfig, {
+      customSettings: '{template:{prerender:false}}',
+    });
+    expect(output.customSettings).toEqual({ template: { prerender: false } });
+  });
+
+  test('?customSettings.template.prerender=false', () => {
+    const output: Partial<Config> = loadParamConfig(defaultConfig, {
+      'customSettings.template.prerender': false,
+    });
+    expect(output.customSettings).toEqual({ template: { prerender: false } });
   });
 });

--- a/src/livecodes/utils/utils.ts
+++ b/src/livecodes/utils/utils.ts
@@ -145,7 +145,8 @@ export const stringToValidJson = /* @__PURE__ */ (str: string) =>
       return '"' + matchedStr.substring(1, matchedStr.length - 1) + '"';
     })
     .replace(
-      /(\w+(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$))(\s*:)(?!(\w*)(?:"))/gm,
+      // /(\w+(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$))(\s*:)(?!(\w*)(?:"))/gm,
+      /(\w+(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$))(\s*:)/gm,
       function quoteNonQuoted(matchedStr) {
         return '"' + matchedStr.substring(0, matchedStr.length - 1).trimEnd() + '":';
       },
@@ -650,6 +651,22 @@ export const getErrorMessage = /* @__PURE__ */ (err: unknown): string => {
     return err.message;
   }
   return String(err);
+};
+
+// addProp({a: {b: 1}}, 'a.c', 2);
+export const addProp = /* @__PURE__ */ (
+  obj: Record<string, unknown>,
+  key: string,
+  value: unknown,
+) => {
+  const keys = key.split('.');
+  if (keys.length === 1) {
+    obj[key] = value;
+    return;
+  }
+  const [first, ...rest] = keys;
+  if (!obj[first]) obj[first] = {};
+  addProp(obj[first] as Record<string, unknown>, rest.join('.'), value);
 };
 
 export const predefinedValues = {

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -473,7 +473,11 @@ export function getPlaygroundUrl(options: EmbedOptions = {}): string {
     playgroundUrl.searchParams.set('headless', 'true');
   }
 
-  playgroundUrl.hash = hashParams.toString();
+  // only override appUrl hash if hashParams is not empty
+  if (hashParams.toString().length > 0) {
+    playgroundUrl.hash = hashParams.toString();
+  }
+
   return playgroundUrl.href;
 }
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update


## Description

- allow setting customSettings in query params like this:

  ```
  ?customSettings={template:{prerender:false}}
  ```
  or this:
  ```
  ?customSettings.template.prerender=false
  ```

- allow return value of `getShareUrl()` to be used as `appUrl`

  example:

  ```js
  import { createPlayground } from 'livecodes';

  const playground = await createPlayground('#container', {
    params: {
      html: '<h1>hello world</h1>',
      css: 'h1 { color: red; }',
      js: 'console.log("hello world");',
      console: 'open',
    }
  });
    

  const url = await playground.getShareUrl();
  console.log(url);

  createPlayground('#container2', { appUrl: url })

  ```


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentations?

- [x] 📓 docs (./docs)
- [ ] 📕 storybook (./storybook)
- [ ] 📜 README.md
- [ ] 🙅 no documentation needed
