### PR TITLE
allow importing stylesheets in markup editor

### DIFF
--- a/src/livecodes/result/result-page.ts
+++ b/src/livecodes/result/result-page.ts
@@ -135,8 +135,8 @@ export const createResultPage = async ({
     ...userDefinedImportmap.imports,
   };
 
-  // stylesheets imported in script editor
-  const stylesheetImports = getImports(code.script.compiled).filter(
+  // stylesheets imported in scripts
+  const stylesheetImports = getImports(code.markup.compiled + '\n' + code.script.compiled).filter(
     (mod) =>
       mod.startsWith('data:text/css') ||
       (mod.endsWith('.css') && (Object.keys(configImports).includes(mod) || !mod.startsWith('.'))),

--- a/src/livecodes/result/result-page.ts
+++ b/src/livecodes/result/result-page.ts
@@ -135,12 +135,19 @@ export const createResultPage = async ({
     ...userDefinedImportmap.imports,
   };
 
-  // stylesheets imported in scripts
-  const stylesheetImports = getImports(code.markup.compiled + '\n' + code.script.compiled).filter(
-    (mod) =>
-      mod.startsWith('data:text/css') ||
-      (mod.endsWith('.css') && (Object.keys(configImports).includes(mod) || !mod.startsWith('.'))),
-  );
+  const markupImports = getImports(code.markup.compiled);
+  const scriptImports = getImports(code.script.compiled);
+
+  // imported stylesheets
+  const stylesheetImports = [
+    ...new Set(
+      [...markupImports, ...scriptImports].filter((mod) => {
+        const isCss = mod.startsWith('data:text/css') || /\.css(\?|#|$)/i.test(mod);
+        const isRelative = mod.startsWith('.');
+        return isCss && (Object.keys(configImports).includes(mod) || !isRelative);
+      }),
+    ),
+  ];
   stylesheetImports.forEach((mod) => {
     const url = configImports[mod] || modulesService.getUrl(mod);
     const stylesheet = dom.createElement('link');
@@ -192,7 +199,7 @@ export const createResultPage = async ({
 
   const scriptCompiler = getLanguageCompiler(code.script.language);
 
-  const scriptImportsInMarkup = getImports(markup).filter(isScriptImport);
+  const scriptImportsInMarkup = markupImports.filter(isScriptImport);
   const scriptImportsInTests =
     runTests && !forExport ? getImports(compiledTests).filter(isScriptImport) : [];
   const importFromScript = Boolean(
@@ -222,7 +229,7 @@ export const createResultPage = async ({
     hasDefaultExport(code.script.compiled) &&
     !hasCustomJsxRuntime(code.script.content || '', config) &&
     !importFromScript;
-  const hasPreact = getImports(code.script.compiled).find((mod) => mod === 'preact');
+  const hasPreact = scriptImports.find((mod) => mod === 'preact');
 
   let compilerImports = {};
 
@@ -261,7 +268,7 @@ export const createResultPage = async ({
           baseUrl,
         });
       }
-      const inlineScript = document.createElement('script');
+      const inlineScript = dom.createElement('script');
       inlineScript.innerHTML = compiler.inlineScript;
       dom.head.appendChild(inlineScript);
     }
@@ -408,7 +415,7 @@ export const createResultPage = async ({
         baseUrl,
       });
     }
-    const inlineModule = document.createElement('script');
+    const inlineModule = dom.createElement('script');
     inlineModule.innerHTML = scriptCompiler.inlineModule;
     inlineModule.type = 'module';
     dom.head.appendChild(inlineModule);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures stylesheets imported from both markup and scripts are detected and applied, preventing missing or inconsistent styling.
  * Deduplicates stylesheet imports and prevents CSS from being loaded as JavaScript, improving page stability.
  * Improves consistency of generated HTML/import maps so runtime styling and component output are more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->