### PR TITLE
Add docs for markdown and MDX

### DIFF
--- a/docs/docs/languages/markdown.mdx
+++ b/docs/docs/languages/markdown.mdx
@@ -156,4 +156,5 @@ https://livecodes.io/?template=markdown
 - [Markdown](https://daringfireball.net/projects/markdown/)
 - [Marked](https://marked.js.org/)
 - [The Markdown Guide](https://www.markdownguide.org/)
+- [MDX support in LiveCodes](./mdx.mdx)
 

--- a/docs/docs/languages/mdx.mdx
+++ b/docs/docs/languages/mdx.mdx
@@ -1,3 +1,109 @@
 # MDX
 
-TODO...
+[MDX](https://mdxjs.com/) allows using JSX in [Markdown](./markdown.mdx), creating dynamic and component-driven content for websites, documentation, and applications.
+
+:::info Note
+
+Please note that Markdown is also supported in LiveCodes and is [documented here](./markdown.mdx).
+
+:::
+
+## Demo
+
+import LiveCodes from '../../src/components/LiveCodes.tsx';
+
+export const mdxConfig = {
+  markup: {
+    language: 'mdx',
+    content: `import { Counter } from './script';
+
+# Counter
+
+<Counter />
+`,},
+  style: {
+    language: 'css',
+    content: `body, body button {
+  text-align: center;
+  font: 1em sans-serif;
+}
+`,
+  },
+  script: {
+    language: 'jsx',
+    content: `import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <p>You clicked {count} times.</p>
+      <button onClick={() => setCount(count + 1)}>
+        click me
+      </button>
+    </div>
+  );
+}
+`,
+  },
+}
+
+<LiveCodes config={mdxConfig}></LiveCodes>
+
+## Usage
+
+Components can be imported from the script editor that uses [JSX](./jsx.mdx) or [React](./react.mdx) by importing from `'./script'` (with no extension).
+
+Example:
+
+```js
+import { ComponentName } from './script';
+```
+
+## Language Info
+
+### Name
+
+`mdx`
+
+### Extension
+
+`.mdx`
+
+### Editor
+
+`script`
+
+## Compiler
+
+[MDX](https://mdxjs.com/)
+
+### Version
+
+`@mdx-js/mdx`: v3.1.0
+
+## Code Formatting
+
+Using [Prettier](https://prettier.io/).
+
+## Custom Settings
+
+[Custom settings](../advanced/custom-settings.mdx) added to the property `mdx` are passed as a JSON object to [`mdx.compile`](https://mdxjs.com/packages/mdx/#compilefile-options). Please check the [documentation](https://mdxjs.com/packages/mdx/#compileoptions) for full reference.
+
+Please note that custom settings should be valid JSON (i.e. functions are not allowed).
+
+
+## Starter Template
+
+https://livecodes.io/?template=mdx
+
+## Links
+
+- [MDX](https://mdxjs.com/)
+- [JSX](https://react.dev/learn/writing-markup-with-jsx)
+- [React](https://react.dev/)
+- [Markdown support in LiveCodes](./markdown.mdx)
+- [JSX support in LiveCodes](./jsx.mdx)
+- [React support in LiveCodes](./react.mdx)
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced placeholders with complete Markdown and MDX language guides.
  * Added overviews, MDX notes, and live demos with configuration and rendering examples.
  * Included styling guidance (GitHub-like CSS), code samples for applying styles, and styled parameter examples.
  * Documented language metadata (names, aliases, extensions, editor), compiler/formatter details, and custom settings with JSON config.
  * Provided starter templates and reference links.
  * No changes to functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->