### PR TITLE
do not add Tailwind compiled CSS in code blocks

### DIFF
--- a/src/livecodes/compiler/compile-blocks.ts
+++ b/src/livecodes/compiler/compile-blocks.ts
@@ -88,6 +88,9 @@ const postProcess = async (content: string, config: Config, language: LanguageOr
   }
 
   for (const processor of window.deps.processors) {
+    // do not place compiled css for tailwind and similar in style blocks
+    if (['tailwindcss', 'unocss', 'windicss'].includes(processor.name)) continue;
+
     if (
       (processorIsEnabled(processor.name, config) &&
         processorIsActivated(processor.name, config) &&

--- a/src/livecodes/languages/tailwindcss/processor-tailwindcss-compiler.ts
+++ b/src/livecodes/languages/tailwindcss/processor-tailwindcss-compiler.ts
@@ -6,6 +6,7 @@ import { modulesService } from '../../services';
 import { getLanguageCustomSettings } from '../../utils/utils';
 import { tailwindcss3Url, tailwindcssBaseUrl, vendorsBaseUrl } from '../../vendors';
 import { lightningcssFeatures } from '../lightningcss/processor-lightningcss-compiler';
+import { addCodeInStyleBlocks } from './utils';
 
 declare const self: any;
 
@@ -186,21 +187,21 @@ self.createTailwindcssCompiler = (): CompilerFunction => {
       },
     });
 
-    return tailwind.generateStylesFromContent(code, [
-      `<template>${options.html}\n<script>${config.script.content}</script></template>`,
-    ]);
+    const html = `<template>${options.html}\n<script>${config.script.content}</script></template>`;
+    return tailwind.generateStylesFromContent(addCodeInStyleBlocks(code, html), [html]);
   };
 
   const tailwind4: CompilerFunction = async (code, { config, options }) => {
-    const prepareCode = (css: string) => {
+    const prepareCode = (css: string, html: string) => {
       let result = replaceStyleImports(css, [/tailwindcss/g]);
       if (!result.includes('@import')) {
         result = `@import "tailwindcss";${result}`;
       }
-      return result;
+      return addCodeInStyleBlocks(result, html);
     };
+
     const html = `<template>${options.html}\n<script>${config.script.content}</script></template>`;
-    const css = prepareCode(code);
+    const css = prepareCode(code, html);
     try {
       const compiler = await self.tailwindcss.compile(css, {
         base: '/',

--- a/src/livecodes/languages/tailwindcss/utils.ts
+++ b/src/livecodes/languages/tailwindcss/utils.ts
@@ -1,0 +1,13 @@
+export const addCodeInStyleBlocks = (css: string, html: string) => {
+  // from compiler/compile-blocks.ts#compileBlocks
+  const getBlockPattern = (el: 'style', langAttr = 'lang') =>
+    `(<${el}\\s*)(?:([\\s\\S]*?)${langAttr}\\s*=\\s*["']([A-Za-z0-9 _]*)["'])?((?:[^>]*)>)([\\s\\S]*?)(<\\/${el}>)`;
+  const pattern = getBlockPattern('style');
+  for (const arr of [...html.matchAll(new RegExp(pattern, 'g'))]) {
+    const content = arr[5];
+    if (content?.trim()) {
+      css += `\n${content}`;
+    }
+  }
+  return css;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tailwind compilation now merges styles from HTML <style> blocks, producing more complete output.
  - Improved Tailwind v3/v4 handling by pairing generated CSS with the corresponding HTML context.

- Bug Fixes
  - Post-processing now skips Tailwind CSS, UnoCSS, and WindiCSS processors, preventing unintended alterations and ensuring consistent styling results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->