### PR TITLE
fix `height` in Vue SDK

### DIFF
--- a/src/sdk/vue.ts
+++ b/src/sdk/vue.ts
@@ -125,7 +125,7 @@ const LiveCodes: LiveCodesComponent = {
         'div',
         {
           ref: containerRef,
-          'data-height': height,
+          'data-height': height.value,
         },
         ctx.slots.default?.() || '',
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the data-height binding in the Vue SDK to use the actual height value, ensuring the root element reflects the intended size.
  * Resolves cases where components did not resize correctly during reactive updates, improving layout stability and consistency across browsers.
  * Enhances compatibility with dynamic styling and theming by applying accurate height attributes, reducing sporadic rendering glitches when height changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->