### PR TITLE
do not show lineNumbers in console editor

### DIFF
--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -1969,11 +1969,12 @@ const loadSelectedScreen = () => {
   return false;
 };
 
-const getAllEditors = (): CodeEditor[] => [
-  ...Object.values(editors),
-  ...[toolsPane?.console?.getEditor?.()],
-  ...[toolsPane?.compiled?.getEditor?.()],
-];
+const getAllEditors = (): CodeEditor[] =>
+  [
+    ...Object.values(editors),
+    toolsPane?.console?.getEditor?.(),
+    toolsPane?.compiled?.getEditor?.(),
+  ].filter((x) => x != null);
 
 const setTheme = (theme: Theme, editorTheme: Config['editorTheme']) => {
   const themes = ['light', 'dark'];

--- a/src/livecodes/editor/monaco/monaco.ts
+++ b/src/livecodes/editor/monaco/monaco.ts
@@ -189,6 +189,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     glyphMargin: true,
     folding: false,
     lineDecorationsWidth: 0,
+    lineNumbers: 'off',
     lineNumbersMinChars: 0,
     scrollbar: {
       vertical: 'auto',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Line numbers are now hidden by default in console and embedded editor views for a cleaner, more compact interface.

* **Bug Fixes**
  * Improved editor handling to avoid occasional issues from missing/invalid editor instances, reducing errors and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->