### PR TITLE
remove links to vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Add this code to your page:
 #### Self-hosted
 
 1. Download a [release](https://github.com/live-codes/livecodes/releases)
-2. Put it on a static file server (for free!) <sup><a href="https://pages.cloudflare.com/" target="_blank" rel="noopener">1</a>, <a href="https://vercel.com/" target="_blank" rel="noopener">2</a>, <a href="https://www.netlify.com/" target="_blank" rel="noopener">3</a>, <a href="https://firebase.google.com/" target="_blank" rel="noopener">4</a>, <a href="https://pages.github.com/" target="_blank" rel="noopener">5</a></sup>
+2. Put it on a static file server (for free!) <sup><a href="https://pages.cloudflare.com/" target="_blank" rel="noopener">1</a>, <a href="https://www.netlify.com/" target="_blank" rel="noopener">2</a>, <a href="https://firebase.google.com/" target="_blank" rel="noopener">3</a>, <a href="https://pages.github.com/" target="_blank" rel="noopener">4</a></sup>
 
    <sup>Check the guide for <a href="https://livecodes.io/docs/features/self-hosting" target="_blank" rel="noopener">self-hosting</a> (including the built-in setup to deploy to GitHub Pages).</sup>
 

--- a/docs/docs/features/self-hosting.mdx
+++ b/docs/docs/features/self-hosting.mdx
@@ -33,7 +33,7 @@ Fork the [GitHub repo](https://github.com/live-codes/livecodes) and clone it. Yo
 
 ### Git Integration
 
-Fork the [GitHub repo](https://github.com/live-codes/livecodes) and use one of the hosting services that integrate with GitHub to allow automatic deploys on code push (e.g. [Cloudflare Pages](https://developers.cloudflare.com/pages/get-started), [Netlify](https://docs.netlify.com/configure-builds/overview/), [Firebase](https://firebase.google.com/docs/hosting/github-integration), [Vercel](https://vercel.com/docs/concepts/git), etc.). When prompted, the build command is `npm run build` and the build output directory is `build`.
+Fork the [GitHub repo](https://github.com/live-codes/livecodes) and use one of the hosting services that integrate with GitHub to allow automatic deploys on code push (e.g. [Cloudflare Pages](https://developers.cloudflare.com/pages/get-started), [Netlify](https://docs.netlify.com/configure-builds/overview/), [Firebase](https://firebase.google.com/docs/hosting/github-integration), etc.). When prompted, the build command is `npm run build` and the build output directory is `build`.
 
 ### Docker Setup
 

--- a/docs/src/components/HomepageFeatures.tsx
+++ b/docs/src/components/HomepageFeatures.tsx
@@ -391,20 +391,16 @@ export default function HomepageFeatures(): ReactNode {
                           1
                         </a>
                         ,{' '}
-                        <a href="https://vercel.com/" target="_blank" rel="noopener">
+                        <a href="https://www.netlify.com/" target="_blank" rel="noopener">
                           2
                         </a>
                         ,{' '}
-                        <a href="https://www.netlify.com/" target="_blank" rel="noopener">
+                        <a href="https://firebase.google.com/" target="_blank" rel="noopener">
                           3
                         </a>
                         ,{' '}
-                        <a href="https://firebase.google.com/" target="_blank" rel="noopener">
-                          4
-                        </a>
-                        ,{' '}
                         <a href="https://pages.github.com/" target="_blank" rel="noopener">
-                          5
+                          4
                         </a>
                       </sup>
                     </li>


### PR DESCRIPTION
LiveCodes should not recommend genocide supporters
https://x.com/rauchg/status/1972669025525158031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated self-hosting guides to remove Vercel from supported hosting options.
  - Adjusted instructions for GitHub-based automatic deploys accordingly.
  - Reordered remaining provider links (Cloudflare Pages, Netlify, Firebase, GitHub Pages).

- Refactor
  - Removed the Vercel link from the homepage self-host steps.
  - Renumbered and reordered the remaining hosting provider tiles to reflect the change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->