### PR TITLE
clean up python-wasm script

### DIFF
--- a/src/livecodes/languages/python-wasm/lang-python-wasm-script.ts
+++ b/src/livecodes/languages/python-wasm/lang-python-wasm-script.ts
@@ -74,7 +74,7 @@ __builtins__.input = input
       try {
         await livecodes.micropip.install(pkg);
       } catch (err) {
-        //
+        // livecodes.excludedPackages.push(pkg);
       }
     }
   }


### PR DESCRIPTION
- matplotlib no longer requires fontAwesome icons
- remove un-necessary comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Stopped automatically injecting the FontAwesome stylesheet into the embedded Python WASM environment to avoid unnecessary asset injection.
  - Simplified environment preparation and removed redundant stylesheet injection logic.
  - Streamlined runtime error paths to consistently log installation and execution failures.

- Chores
  - Removed outdated guidance and historical comments about runtime timing and alternative execution paths.
  - Standardized logging for failure paths to improve diagnostics without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->