### PR TITLE
upgrade svelte to v5.39.12

### DIFF
--- a/docs/docs/languages/svelte.mdx
+++ b/docs/docs/languages/svelte.mdx
@@ -202,7 +202,7 @@ The official [Svelte compiler](https://svelte.dev/docs/svelte/svelte-compiler).
 
 ### Version
 
-`svelte`: v5.12.0
+`svelte`: v5.39.12
 
 ## Code Formatting
 

--- a/src/livecodes/languages/svelte/lang-svelte.ts
+++ b/src/livecodes/languages/svelte/lang-svelte.ts
@@ -1,4 +1,5 @@
 import type { LanguageSpecs } from '../../models';
+import { modulesService } from '../../services';
 import { svelteBaseUrl } from '../../vendors';
 import { parserPlugins } from '../prettier';
 
@@ -16,14 +17,18 @@ export const svelte: LanguageSpecs = {
       return (self as any).createSvelteCompiler();
     },
     imports: {
-      // from https://unpkg.com/svelte/package.json => "exports"
+      // from https://github.com/sveltejs/svelte/blob/main/packages/svelte/package.json
+      '#client/constants': svelteBaseUrl + 'src/internal/client/constants.js',
+      '#compiler/builders': svelteBaseUrl + 'src/compiler/utils/builders.js',
       svelte: svelteBaseUrl + 'src/index-client.js',
       'svelte/animate': svelteBaseUrl + 'src/animate/index.js',
+      'svelte/attachments': svelteBaseUrl + 'src/attachments/index.js',
       'svelte/easing': svelteBaseUrl + 'src/easing/index.js',
       'svelte/internal': svelteBaseUrl + 'src/internal/index.js',
       'svelte/internal/client': svelteBaseUrl + 'src/internal/client/index.js',
       'svelte/internal/disclose-version': svelteBaseUrl + 'src/internal/disclose-version.js',
       'svelte/internal/flags/legacy': svelteBaseUrl + 'src/internal/flags/legacy.js',
+      'svelte/internal/flags/tracing': svelteBaseUrl + 'src/internal/flags/tracing.js',
       'svelte/internal/server': svelteBaseUrl + 'src/internal/server/index.js',
       'svelte/legacy': svelteBaseUrl + 'src/legacy/legacy-client.js',
       'svelte/motion': svelteBaseUrl + 'src/motion/index.js',
@@ -33,7 +38,8 @@ export const svelte: LanguageSpecs = {
       'svelte/store': svelteBaseUrl + 'src/store/index-client.js',
       'svelte/transition': svelteBaseUrl + 'src/transition/index.js',
       'svelte/events': svelteBaseUrl + 'src/events/index.js',
-      'esm-env': 'https://esm.sh/esm-env',
+      clsx: modulesService.getModuleUrl('clsx'),
+      'esm-env': modulesService.getModuleUrl('esm-env'),
     },
     inlineScript: 'globalThis.process = { env: { NODE_ENV: "production" } };',
   },

--- a/src/livecodes/vendors.ts
+++ b/src/livecodes/vendors.ts
@@ -413,7 +413,7 @@ export const stencilUrl = /* @__PURE__ */ getUrl('@stencil/core@3.2.2/compiler/s
 
 export const stylisUrl = /* @__PURE__ */ getUrl('stylis@4.3.2/dist/umd/stylis.js');
 
-export const svelteBaseUrl = /* @__PURE__ */ getUrl('svelte@5.12.0/');
+export const svelteBaseUrl = /* @__PURE__ */ getUrl('svelte@5.39.12/');
 
 export const svgbobWasmCdnUrl = /* @__PURE__ */ getUrl('svgbob-wasm@0.4.1-a0/svgbob_wasm_bg.wasm');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded bundled Svelte runtime to v5.39.12 for improved compatibility and stability.
  * Expanded Svelte language support to resolve additional standard modules, improving project builds that rely on newer utilities and flags.

* **Documentation**
  * Updated Svelte version references in the docs to v5.39.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->