### PR TITLE
fix command menu hotkey

### DIFF
--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -2859,7 +2859,7 @@ const handleCommandMenu = async () => {
     // Ctrl+K opens the command menu
     // do not open the menu if shortcut is Ctrl+Shift+K
     // wait for 500ms to allow other shortcuts like Ctrl+K Ctrl+0
-    if (!ctrl(e) || e.shiftKey) {
+    if (!ctrl(e) || e.shiftKey || e.altKey) {
       anotherShortcut = false;
       return;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard shortcut handling to prevent the command menu from opening when Alt key is pressed alongside Ctrl+K, preventing unintended conflicts with alternative shortcut combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->