### PR TITLE
doc: Add Sass language documentation, new compression.

### DIFF
--- a/docs/docs/languages/sass.mdx
+++ b/docs/docs/languages/sass.mdx
@@ -13,6 +13,7 @@ Sass has two syntaxes. The **indented syntax** (`.sass`) is documented here. For
 ## Demo
 
 export const sassConfig = {
+  activeEditor: 'style',
   markup: {
     language: 'html',
     content: `<div class="container">

--- a/docs/docs/languages/sass.mdx
+++ b/docs/docs/languages/sass.mdx
@@ -116,10 +116,6 @@ Please note that custom settings should be valid JSON (i.e. functions are not al
 Code formatting is not supported for the Sass indented syntax. 
 [Prettier](https://prettier.io/) supports SCSS (`.scss`) but not the indented `.sass` syntax.
 
-## Starter Template
-
-https://livecodes.io/?template=blank&style.language=sass
-
 ## Links
 
 - [Sass Official Website](https://sass-lang.com/)

--- a/docs/docs/languages/sass.mdx
+++ b/docs/docs/languages/sass.mdx
@@ -112,7 +112,7 @@ Please note that custom settings should be valid JSON (i.e. functions are not al
 
 ## Code Formatting
 
-+Code formatting is not supported for the Sass indented syntax. 
+Code formatting is not supported for the Sass indented syntax. 
 [Prettier](https://prettier.io/) supports SCSS (`.scss`) but not the indented `.sass` syntax.
 
 ## Starter Template

--- a/docs/docs/languages/sass.mdx
+++ b/docs/docs/languages/sass.mdx
@@ -77,6 +77,46 @@ Sass uses the **indented syntax**, which relies on indentation instead of curly 
 
 For more details about CSS support in LiveCodes, including CSS processors, style imports, CSS modules, and CSS frameworks, see the [CSS feature documentation](../features/css.mdx).
 
+## Loading External Styles
+
+Sass supports loading external stylesheets and modules using `@use`, `@import`, and `meta.load-css()`. [Bare module](../features/module-resolution.mdx#bare-module-imports) specifiers are resolved to full CDN URLs.
+
+### Using `@use`
+
+You can load npm packages with `@use`:
+
+```sass
+@use "bootstrap/scss/bootstrap" as *
+```
+
+### Using `@import`
+
+You can import external modules and use their mixins:
+
+```sass
+@import 'sass-utils'
+
+.center
+  @include block--center
+  width: fit-content
+```
+
+### Using `meta.load-css()`
+
+You can dynamically load stylesheets from URLs using the built-in `sass:meta` module:
+
+```sass
+@use "sass:meta"
+
+@include meta.load-css("https://raw.githubusercontent.com/live-codes/livecodes/refs/heads/develop/src/livecodes/styles/app.scss")
+```
+
+:::tip
+
+For more information about loading and importing styles, see the [Style Imports](../features/css.mdx#style-imports) documentation.
+
+:::
+
 ## Language Info
 
 ### Name

--- a/docs/docs/languages/sass.mdx
+++ b/docs/docs/languages/sass.mdx
@@ -1,3 +1,127 @@
 # Sass
 
-TODO...
+import LiveCodes from '../../src/components/LiveCodes.tsx';
+
+[Sass](https://sass-lang.com/) (Syntactically Awesome Style Sheets) is a CSS preprocessor that uses the indented syntax (no curly braces or semicolons). It adds features like variables, nesting, mixins, and functions to CSS.
+
+:::info
+
+Sass has two syntaxes. The **indented syntax** (`.sass`) is documented here. For the **SCSS syntax** (`.scss`), which uses curly braces and semicolons like CSS, see [SCSS](./scss.mdx).
+
+:::
+
+## Demo
+
+export const sassConfig = {
+  markup: {
+    language: 'html',
+    content: `<div class="container">
+  <h1>Hello, Sass!</h1>
+  <p>This is styled with <strong>Sass</strong> indented syntax.</p>
+  <ul class="features">
+    <li>Variables</li>
+    <li>Nesting</li>
+    <li>Mixins</li>
+  </ul>
+</div>
+`,
+  },
+  style: {
+    language: 'sass',
+    content: `$primary: #3182ce
+$bg: #f0f4f8
+$radius: 8px
+
+=flex-center
+  display: flex
+  gap: 1em
+
+.container
+  font-family: sans-serif
+  max-width: 600px
+  margin: 2em auto
+  padding: 1.5em
+  border-radius: $radius
+  background: $bg
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1)
+
+  h1
+    color: #2d3748
+
+  p
+    color: #4a5568
+    line-height: 1.6
+
+.features
+  +flex-center
+  list-style: none
+  padding: 0
+
+  li
+    background: $primary
+    color: white
+    padding: 0.5em 1em
+    border-radius: $radius
+`,
+  },
+};
+
+<LiveCodes config={sassConfig} />
+
+## Usage
+
+Sass code added to the [style editor](../features/projects.mdx#style-editor) is compiled to CSS before being added to the [result page](../features/result.mdx).
+
+Sass uses the **indented syntax**, which relies on indentation instead of curly braces and newlines instead of semicolons.
+
+For more details about CSS support in LiveCodes, including CSS processors, style imports, CSS modules, and CSS frameworks, see the [CSS feature documentation](../features/css.mdx).
+
+## Language Info
+
+### Name
+
+`sass`
+
+### Extensions
+
+`.sass`
+
+### Editor
+
+`style`
+
+## Compiler
+
+[Sass](https://sass-lang.com/) is compiled using the official [Dart Sass](https://sass-lang.com/dart-sass/) compiler (running in the browser).
+
+### Custom Settings
+
+[Custom settings](../advanced/custom-settings.mdx) added to the property `sass` are passed as a JSON object to the Sass compiler during compile. Please check the [Sass JavaScript API documentation](https://sass-lang.com/documentation/js-api/interfaces/stringoptions/) for full reference.
+
+Please note that custom settings should be valid JSON (i.e. functions are not allowed).
+
+**Example:**
+
+```json title="Custom Settings"
+{
+  "sass": {
+    "style": "compressed"
+  }
+}
+```
+
+## Code Formatting
+
+Using [Prettier](https://prettier.io/).
+
+## Starter Template
+
+https://livecodes.io/?template=blank&style.language=sass
+
+## Links
+
+- [Sass Official Website](https://sass-lang.com/)
+- [Sass Documentation](https://sass-lang.com/documentation/)
+- [Sass Indented Syntax](https://sass-lang.com/documentation/syntax/#the-indented-syntax)
+- [SCSS in LiveCodes](./scss.mdx)
+- [CSS feature documentation in LiveCodes](../features/css.mdx)

--- a/docs/docs/languages/sass.mdx
+++ b/docs/docs/languages/sass.mdx
@@ -112,7 +112,8 @@ Please note that custom settings should be valid JSON (i.e. functions are not al
 
 ## Code Formatting
 
-Using [Prettier](https://prettier.io/).
++Code formatting is not supported for the Sass indented syntax. 
+[Prettier](https://prettier.io/) supports SCSS (`.scss`) but not the indented `.sass` syntax.
 
 ## Starter Template
 

--- a/src/livecodes/languages/scss/lang-scss-compiler.ts
+++ b/src/livecodes/languages/scss/lang-scss-compiler.ts
@@ -58,8 +58,6 @@ import { getLanguageCustomSettings } from '../../utils';
             const urlString = canonicalUrl.href;
             const extension = '.' + language; // .scss or .sass
             const result: Promise<{ contents: string; syntax: string }> = fetchStyles(urlString)
-              .catch(() => fetchStyles(urlString + extension))
-              .catch(() => fetchStyles(urlString + '.css'))
               .catch(() => {
                 const urlParts = urlString.split('/');
                 const filename = urlParts[urlParts.length - 1];
@@ -67,6 +65,8 @@ import { getLanguageCustomSettings } from '../../utils';
                 urlParts[urlParts.length - 1] = prefix + filename + extension;
                 return fetchStyles(urlParts.join('/'));
               })
+              .catch(() => fetchStyles(urlString + extension))
+              .catch(() => fetchStyles(urlString + '.css'))
               .catch(() => fetchStyles(urlString + '/_index' + extension))
               .catch(
                 () =>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ♻️ Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
- [ ] 🌐 Internationalization / Translation

## Description

This PR adds the documentation for the **Sass (indented syntax)** language page, which was previously a placeholder (`TODO...`).

The new documentation includes:
- Introduction and syntax distinction between Sass and SCSS.
- Live interactive demo showcasing Sass indented syntax (variables, nesting, mixins).
- Technical details about the compiler (Dart Sass) and code formatting.
- Links to official resources and related LiveCodes features.

## Related Tickets & Documents

Close #769 

## Desktop Recordings

https://github.com/user-attachments/assets/07957537-4adc-484a-bd05-12cf72171a59



## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentations?

- [x] 📓 docs (./docs)
- [ ] 📕 storybook (./storybook)
- [ ] 📜 README.md
- [ ] 🙅 no documentation needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced placeholder with a full Sass documentation page featuring an interactive LiveCodes demo, expanded usage notes, language/editor info, compiler guidance, custom settings, formatting notes, a starter template link, and references.
* **Bug Fixes / Improvements**
  * Faster, more reliable Sass/SCSS demo loading with improved fallback resolution, asynchronous handling, and caching to reduce repeated fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->