### PR TITLE
minimap

### DIFF
--- a/docs/docs/configuration/configuration-object.mdx
+++ b/docs/docs/configuration/configuration-object.mdx
@@ -681,6 +681,14 @@ Default: `false`
 
 When set to `true`, regions marked by `#region` and `#endregion` comments are folded when the project is loaded.
 
+### `minimap`
+
+Type: [`boolean`](../api/interfaces/Config.md#minimap)
+
+Default: `false`
+
+Enables minimap in code editor.
+
 ### `emmet`
 
 Type: [`boolean`](../api/interfaces/Config.md#emmet)

--- a/docs/docs/features/editor-settings.mdx
+++ b/docs/docs/features/editor-settings.mdx
@@ -48,6 +48,7 @@ These include:
 - [Word-wrap](../configuration/configuration-object.mdx#wordwrap)
 - [Auto-close brackets and quotes](../configuration/configuration-object.mdx#closebrackets)
 - [Fold (collapse) regions](../configuration/configuration-object.mdx#foldregions)
+- [Minimap](../configuration/configuration-object.mdx#minimap)
 
 ### Emmet
 

--- a/src/livecodes/UI/editor-settings.ts
+++ b/src/livecodes/UI/editor-settings.ts
@@ -245,6 +245,11 @@ export const createEditorSettingsUI = async ({
       help: `${process.env.DOCS_BASE_URL}configuration/configuration-object#foldregions`,
     },
     {
+      title: window.deps.translateString('editorSettings.minimap', 'Enable Minimap *'),
+      name: 'minimap',
+      options: [{ value: 'true' }],
+    },
+    {
       title: window.deps.translateString('editorSettings.emmet', 'Enable Emmet *'),
       name: 'emmet',
       options: [{ value: 'true' }],

--- a/src/livecodes/config/config.ts
+++ b/src/livecodes/config/config.ts
@@ -81,6 +81,7 @@ export const getEditorConfig = (config: Config | UserConfig): EditorConfig =>
     wordWrap: config.wordWrap,
     closeBrackets: config.closeBrackets,
     foldRegions: config.foldRegions,
+    minimap: config.minimap,
     emmet: config.emmet,
     // enableAI: config.enableAI,
     editorMode: config.editorMode,

--- a/src/livecodes/config/default-config.ts
+++ b/src/livecodes/config/default-config.ts
@@ -66,6 +66,7 @@ export const defaultConfig: Config = {
   semicolons: true,
   singleQuote: false,
   trailingComma: true,
+  minimap: false,
   emmet: true,
   // enableAI: false,
   editorMode: undefined,

--- a/src/livecodes/config/validate-config.ts
+++ b/src/livecodes/config/validate-config.ts
@@ -179,6 +179,7 @@ export const validateConfig = (config: Partial<Config>): Partial<Config> => {
     ...(is(config.semicolons, 'boolean') ? { semicolons: config.semicolons } : {}),
     ...(is(config.singleQuote, 'boolean') ? { singleQuote: config.singleQuote } : {}),
     ...(is(config.trailingComma, 'boolean') ? { trailingComma: config.trailingComma } : {}),
+    ...(is(config.minimap, 'boolean') ? { minimap: config.minimap } : {}),
     ...(is(config.emmet, 'boolean') ? { emmet: config.emmet } : {}),
     // ...(is(config.enableAI, 'boolean') ? { enableAI: config.enableAI } : {}),
     ...(includes(editorModes, config.editorMode) ? { editorMode: config.editorMode } : {}),

--- a/src/livecodes/editor/codemirror/codemirror.ts
+++ b/src/livecodes/editor/codemirror/codemirror.ts
@@ -43,7 +43,7 @@ import type {
   Theme,
 } from '../../models';
 import { ctrl, debounce, getRandomString } from '../../utils/utils';
-import { codeMirrorBaseUrl, comlinkBaseUrl } from '../../vendors';
+import { codeMirrorBaseUrl, codemirrorMinimapUrl, comlinkBaseUrl } from '../../vendors';
 import { getEditorTheme } from '../themes';
 import { codemirrorThemes, customThemes } from './codemirror-themes';
 import { editorLanguages } from './editor-languages';
@@ -120,6 +120,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
   let codemirrorTS: Extension[] | undefined;
   let vim: (() => Extension) | undefined;
   let emacs: (() => Extension) | undefined;
+  let minimap: Extension | undefined;
   let emmet: Extension | undefined;
   // let codeium:
   //   | ((editors: CodeiumEditor[], mapLanguage: (lang: Language) => Language) => Extension)
@@ -192,20 +193,23 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     const modules = {
       vim: `${codeMirrorBaseUrl}codemirror-vim.js`,
       emacs: `${codeMirrorBaseUrl}codemirror-emacs.js`,
+      minimap: codemirrorMinimapUrl,
       emmet: `${codeMirrorBaseUrl}codemirror-emmet.js`,
       // codeium: `${codeMirrorBaseUrl}codemirror-codeium.js`,
       lineNumbersRelative: `${codeMirrorBaseUrl}codemirror-line-numbers-relative.js`,
     };
-    const [vimMod, emacsMod, emmetMod, /* codeiumMod, */ lineNumbersRelativeMod] =
+    const [vimMod, emacsMod, minimapMod, emmetMod, /* codeiumMod, */ lineNumbersRelativeMod] =
       await Promise.all([
         opt.editorMode === 'vim' ? import(modules.vim) : Promise.resolve({}),
         opt.editorMode === 'emacs' ? import(modules.emacs) : Promise.resolve({}),
+        opt.minimap ? import(modules.minimap) : Promise.resolve({}),
         opt.emmet ? import(modules.emmet) : Promise.resolve({}),
         // opt.enableAI ? import(modules.codeium) : Promise.resolve({}),
         opt.lineNumbers === 'relative' ? import(modules.lineNumbersRelative) : Promise.resolve({}),
       ]);
     vim = vimMod.vim;
     emacs = emacsMod.emacs;
+    minimap = minimapMod.showMinimap;
     emmet = emmetMod.emmet;
     // codeium = codeiumMod.codeium;
     lineNumbersRelative = lineNumbersRelativeMod.lineNumbersRelative;
@@ -228,6 +232,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     const tabSize = settings.tabSize ?? editorSettings.tabSize;
     const useTabs = settings.useTabs ?? editorSettings.useTabs;
     const wordWrap = settings.wordWrap ?? editorSettings.wordWrap;
+    const enableMinimap = settings.minimap ?? editorSettings.minimap;
     const enableEmmet = settings.emmet ?? editorSettings.emmet;
     const enableLineNumbers = settings.lineNumbers ?? editorSettings.lineNumbers;
     // const enableAI = settings.enableAI ?? editorSettings.enableAI;
@@ -238,6 +243,13 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
       indentUnit.of(useTabs ? '\t' : ' '.repeat(tabSize)),
       ...(wordWrap ? [EditorView.lineWrapping] : []),
       ...(editorMode === 'vim' && vim ? [vim()] : editorMode === 'emacs' && emacs ? [emacs()] : []),
+      ...(enableMinimap && minimap
+        ? [
+            minimap.compute(['doc'], () => ({
+              create: () => ({ dom: document.createElement('div') }),
+            })),
+          ]
+        : []),
       ...(enableEmmet && emmet ? [emmet] : []),
       ...(enableLineNumbers === 'relative' && lineNumbersRelative
         ? [lineNumbersRelative()]

--- a/src/livecodes/editor/monaco/monaco.ts
+++ b/src/livecodes/editor/monaco/monaco.ts
@@ -75,6 +75,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     autoClosingBrackets: opt.closeBrackets ? 'always' : 'never',
     autoClosingQuotes: opt.closeBrackets ? 'always' : 'never',
     autoClosingDelete: opt.closeBrackets ? 'always' : 'never',
+    minimap: { enabled: opt.minimap, scale: 1.5 },
   });
 
   const baseOptions = convertOptions(options);
@@ -135,7 +136,6 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     fontLigatures: true,
     formatOnType: false,
     lineNumbersMinChars: 3,
-    minimap: { enabled: false },
     scrollbar: { useShadows: false },
     mouseWheelZoom: false,
     automaticLayout: true,
@@ -179,6 +179,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     },
     scrollBeyondLastLine: false,
     contextmenu: false,
+    minimap: { enabled: false },
   };
 
   const embedOptions: Options = {

--- a/src/livecodes/html/app.html
+++ b/src/livecodes/html/app.html
@@ -36,7 +36,8 @@
           "@lezer/lr": "{{codemirrorCoreUrl}}",
           "@replit/codemirror-indentation-markers": "{{codemirrorCoreUrl}}",
           "@replit/codemirror-vscode-keymap": "{{codemirrorCoreUrl}}",
-          "@replit/codemirror-css-color-picker": "{{codemirrorCoreUrl}}"
+          "@replit/codemirror-css-color-picker": "{{codemirrorCoreUrl}}",
+          "crelt": "{{creltUrl}}"
         }
       }
     </script>

--- a/src/livecodes/i18n/locales/en/translation.lokalise.json
+++ b/src/livecodes/i18n/locales/en/translation.lokalise.json
@@ -1276,6 +1276,10 @@
     "notes": "",
     "translation": "Relative line numbers *"
   },
+  "editorSettings.minimap": {
+    "notes": "",
+    "translation": "Enable Minimap *"
+  },
   "editorSettings.notAvailableInCodeJar": {
     "notes": "",
     "translation": "Not available in CodeJar"

--- a/src/livecodes/i18n/locales/en/translation.ts
+++ b/src/livecodes/i18n/locales/en/translation.ts
@@ -511,6 +511,7 @@ const translation = {
     heading: 'Editor Settings',
     lineNumbers: 'Show line numbers',
     lineNumbersRelative: 'Relative line numbers *',
+    minimap: 'Enable Minimap *',
     notAvailableInCodeJar: 'Not available in CodeJar',
     preview: 'Preview',
     semicolons: 'Format: Use Semicolons',

--- a/src/livecodes/main.ts
+++ b/src/livecodes/main.ts
@@ -5,7 +5,7 @@ import appHTML from './html/app.html?raw';
 import type { API, CDN, Config, CustomEvents, EmbedOptions } from './models';
 import { modulesService } from './services/modules';
 import { isInIframe } from './utils/utils';
-import { codeMirrorBaseUrl, esModuleShimsPath } from './vendors';
+import { codeMirrorBaseUrl, creltUrl, esModuleShimsPath } from './vendors';
 
 export type { API, Config };
 
@@ -107,6 +107,7 @@ export const livecodes = (container: string, config: Partial<Config> = {}): Prom
     `,
           )
           .replace(/{{codemirrorCoreUrl}}/g, `${codeMirrorBaseUrl}codemirror-core.js`)
+          .replace(/{{creltUrl}}/g, creltUrl)
           .replace(/src="[^"]*?\.svg"/g, (str: string) => (isHeadless ? 'src=""' : str))
           .replace(
             /{{codeiumMeta}}/g,

--- a/src/livecodes/vendors.ts
+++ b/src/livecodes/vendors.ts
@@ -92,6 +92,10 @@ export const codeiumProviderUrl = /* @__PURE__ */ getUrl(
 
 export const codeMirrorBaseUrl = /* @__PURE__ */ getUrl('@live-codes/codemirror@0.3.4/build/');
 
+export const codemirrorMinimapUrl = /* @__PURE__ */ getUrl(
+  '@replit/codemirror-minimap@0.5.2/dist/index.js',
+);
+
 export const coffeeScriptUrl = /* @__PURE__ */ getUrl(
   'coffeescript@2.7.0/lib/coffeescript-browser-compiler-legacy/coffeescript.js',
 );
@@ -101,6 +105,8 @@ export const colorisBaseUrl = /* @__PURE__ */ getUrl('@melloware/coloris@0.22.0/
 export const comlinkBaseUrl = /* @__PURE__ */ getUrl('comlink@4.4.1/dist/');
 
 export const cppWasmBaseUrl = /* @__PURE__ */ getUrl('@chriskoch/cpp-wasm@1.0.2/');
+
+export const creltUrl = /* @__PURE__ */ getUrl('crelt@1.0.6/index.js');
 
 export const csharpWasmBaseUrl = /* @__PURE__ */ getUrl('@seth0x41/csharp-wasm@1.0.3/');
 

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -801,6 +801,12 @@ export interface EditorConfig {
   closeBrackets: boolean;
 
   /**
+   * Show minimap.
+   * @default false
+   */
+  minimap: boolean;
+
+  /**
    * Enables [Emmet](https://livecodes.io/docs/features/editor-settings#emmet).
    * @default true
    */

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -801,7 +801,7 @@ export interface EditorConfig {
   closeBrackets: boolean;
 
   /**
-   * Show minimap.
+   * Enables minimap in code editor.
    * @default false
    */
   minimap: boolean;


### PR DESCRIPTION
This PR allows adding minimap in code editor (monaco and codemirror).

A new `minimap` boolean config option is added (defaults to `false`).

It can be set from the editor settings screen, config object or the `?minimap` param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added minimap functionality to the code editor. Users can configure the minimap through editor settings. The feature is disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->