### PR TITLE
Add a config option to disable home link in embeds

### DIFF
--- a/docs/docs/configuration/configuration-object.mdx
+++ b/docs/docs/configuration/configuration-object.mdx
@@ -448,6 +448,14 @@ Default: `1`
 
 Sets result page [zoom level](../features/result.mdx#result-page-zoom).
 
+### `disableHomeLink`
+
+Type: [`boolean`](../api/interfaces/Config.md#disablehomelink)
+
+Default: `false`
+
+If `true`, the link on LiveCodes logo ("Edit on LiveCodes") is disabled in [embeds](../features/embeds.mdx).
+
 ## User Settings
 
 These are properties that define the [user settings](./../features/user-settings.mdx), including [editor settings](../features/editor-settings.mdx).

--- a/docs/docs/contribution/config-system.mdx
+++ b/docs/docs/contribution/config-system.mdx
@@ -25,7 +25,7 @@ graph TD
         A --> E[validate-config.ts]
         A --> F[upgrade-config.ts]
     end
-    
+
     B["Default configuration values"]
     C["Configuration builder"]
     D["Config getters/setters"]
@@ -330,7 +330,7 @@ setConfig(buildConfig(savedConfig));
 
 ### Language Aliases
 
-Language names are normalized to canonical names:  
+Language names are normalized to canonical names:
 (e.g. `md` becomes `markdown`, `ts` becomes `typescript`)
 
 ```typescript
@@ -386,6 +386,12 @@ const fixLanguageNames = (config: Config): Config => ({
    ```
 
 6. **Document the property** in `docs/docs/configuration/configuration-object.mdx`.
+
+7. **Add it to Storybook** in `storybook/common/arg-types.ts`.
+
+8. **Add stories** in `storybook/_stories/EmbedOptions/config.ts`.
+
+9. **Add tests** in `e2e/specs/config.spec.ts`.
 
 ## Related Documentation
 

--- a/src/livecodes/config/config.ts
+++ b/src/livecodes/config/config.ts
@@ -49,6 +49,7 @@ export const getAppConfig = (config: Config | AppConfig): AppConfig =>
     mode: config.mode,
     tools: config.tools,
     zoom: config.zoom,
+    disableHomeLink: config.disableHomeLink,
   });
 
 export const getUserConfig = (config: Config | UserConfig): UserConfig =>

--- a/src/livecodes/config/default-config.ts
+++ b/src/livecodes/config/default-config.ts
@@ -70,5 +70,6 @@ export const defaultConfig: Config = {
   emmet: true,
   // enableAI: false,
   editorMode: undefined,
+  disableHomeLink: false,
   version: process.env.VERSION as string,
 };

--- a/src/livecodes/config/validate-config.ts
+++ b/src/livecodes/config/validate-config.ts
@@ -185,6 +185,7 @@ export const validateConfig = (config: Partial<Config>): Partial<Config> => {
     ...(includes(editorModes, config.editorMode) ? { editorMode: config.editorMode } : {}),
     ...(is(config.imports, 'object') ? { imports: config.imports } : {}),
     ...(is(config.types, 'object') ? { types: config.types } : {}),
+    ...(is(config.disableHomeLink, 'boolean') ? { disableHomeLink: config.disableHomeLink } : {}),
     ...(is(config.version, 'string') ? { version: config.version } : {}),
   };
 };

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -5035,15 +5035,23 @@ const configureEmbed = (eventsManager: EventsManager) => {
   document.body.classList.add('embed');
 
   const logoLink = UI.getLogoLink();
-  logoLink.title = window.deps.translateString('generic.embed.logoHint', 'Edit on LiveCodes 🡕');
-
-  eventsManager.addEventListener(logoLink, 'click', async (event: Event) => {
-    event.preventDefault();
-    window.open(
-      (await share(/* shortUrl= */ false, /* contentOnly= */ true, /* urlUpdate= */ false)).url,
-      '_blank',
-    );
-  });
+  const { disableHomeLink } = getConfig();
+  if (disableHomeLink) {
+    logoLink.title = 'LiveCodes';
+    logoLink.style.cursor = 'default';
+    eventsManager.addEventListener(logoLink, 'click', async (event: Event) => {
+      event.preventDefault();
+    });
+  } else {
+    logoLink.title = window.deps.translateString('generic.embed.logoHint', 'Edit on LiveCodes 🡕');
+    eventsManager.addEventListener(logoLink, 'click', async (event: Event) => {
+      event.preventDefault();
+      window.open(
+        (await share(/* shortUrl= */ false, /* contentOnly= */ true, /* urlUpdate= */ false)).url,
+        '_blank',
+      );
+    });
+  }
 };
 
 const configureLite = () => {

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -1073,6 +1073,13 @@ export interface AppConfig {
    * Sets result page [zoom level](https://livecodes.io/docs/features/result#result-page-zoom).
    */
   zoom: 1 | 0.5 | 0.25;
+
+  /**
+   * If `true`, the link on LiveCodes logo ("Edit on LiveCodes") is disabled in [embeds](https://livecodes.io/docs/features/embeds).
+   *
+   * @default false
+   */
+  disableHomeLink: boolean;
 }
 
 /**

--- a/storybook/_stories/EmbedOptions/config.ts
+++ b/storybook/_stories/EmbedOptions/config.ts
@@ -259,6 +259,14 @@ const storyDef: StoryDef = {
     },
   },
 
+  disableHomeLink: {
+    props: {
+      config: {
+        disableHomeLink: true,
+      },
+    },
+  },
+
   ConfigJsonURL: {
     props: {
       config:

--- a/storybook/common/arg-types.ts
+++ b/storybook/common/arg-types.ts
@@ -657,6 +657,13 @@ If set to \`"auto"\`, Monaco editor is used on desktop and CodeMirror is used on
     control: 'inline-radio',
     options: ['vim', 'emacs'],
   },
+  config__disableHomeLink: {
+    ...getControlInfo('config__disableHomeLink'),
+    description:
+      'If `true`, the link on LiveCodes logo ("Edit on LiveCodes") is disabled in [embeds](https://livecodes.io/docs/features/embeds).',
+    type: 'boolean',
+    control: 'boolean',
+  },
 };
 
 export const argTypes: Partial<

--- a/storybook/preact/stories/EmbedOptions/config.stories.ts
+++ b/storybook/preact/stories/EmbedOptions/config.stories.ts
@@ -101,6 +101,7 @@ export const ModeResultCompiledOpen = livecodesStory({
   template: 'javascript',
   config: { mode: 'result', tools: { enabled: 'all', active: 'compiled', status: 'open' } },
 });
+export const disableHomeLink = livecodesStory({ config: { disableHomeLink: true } });
 export const ConfigJsonURL = livecodesStory({
   config:
     'https://raw.githubusercontent.com/hatemhosny/typescript-demo-for-testing-import-/gh-pages/src/livecodes.json',

--- a/storybook/react/stories/EmbedOptions/config.stories.ts
+++ b/storybook/react/stories/EmbedOptions/config.stories.ts
@@ -101,6 +101,7 @@ export const ModeResultCompiledOpen = livecodesStory({
   template: 'javascript',
   config: { mode: 'result', tools: { enabled: 'all', active: 'compiled', status: 'open' } },
 });
+export const disableHomeLink = livecodesStory({ config: { disableHomeLink: true } });
 export const ConfigJsonURL = livecodesStory({
   config:
     'https://raw.githubusercontent.com/hatemhosny/typescript-demo-for-testing-import-/gh-pages/src/livecodes.json',

--- a/storybook/solid/src/solid.ts
+++ b/storybook/solid/src/solid.ts
@@ -8,9 +8,10 @@
  */
 
 import { createComponent } from '@live-codes/solid-sdk';
-import type { EmbedOptions, Playground } from 'livecodes';
-import { createPlayground } from 'livecodes';
 import type { Component, JSX } from 'solid-js';
+import { createPlayground } from 'livecodes';
+// eslint-disable-next-line import/order
+import type { EmbedOptions, Playground } from 'livecodes';
 export type { Code, Config, EmbedOptions, Language, Playground } from 'livecodes';
 
 /**

--- a/storybook/solid/stories/EmbedOptions/config.stories.ts
+++ b/storybook/solid/stories/EmbedOptions/config.stories.ts
@@ -101,6 +101,7 @@ export const ModeResultCompiledOpen = livecodesStory({
   template: 'javascript',
   config: { mode: 'result', tools: { enabled: 'all', active: 'compiled', status: 'open' } },
 });
+export const disableHomeLink = livecodesStory({ config: { disableHomeLink: true } });
 export const ConfigJsonURL = livecodesStory({
   config:
     'https://raw.githubusercontent.com/hatemhosny/typescript-demo-for-testing-import-/gh-pages/src/livecodes.json',

--- a/storybook/svelte/stories/EmbedOptions/config.stories.ts
+++ b/storybook/svelte/stories/EmbedOptions/config.stories.ts
@@ -101,6 +101,7 @@ export const ModeResultCompiledOpen = livecodesStory({
   template: 'javascript',
   config: { mode: 'result', tools: { enabled: 'all', active: 'compiled', status: 'open' } },
 });
+export const disableHomeLink = livecodesStory({ config: { disableHomeLink: true } });
 export const ConfigJsonURL = livecodesStory({
   config:
     'https://raw.githubusercontent.com/hatemhosny/typescript-demo-for-testing-import-/gh-pages/src/livecodes.json',

--- a/storybook/vue/stories/EmbedOptions/config.stories.ts
+++ b/storybook/vue/stories/EmbedOptions/config.stories.ts
@@ -101,6 +101,7 @@ export const ModeResultCompiledOpen = livecodesStory({
   template: 'javascript',
   config: { mode: 'result', tools: { enabled: 'all', active: 'compiled', status: 'open' } },
 });
+export const disableHomeLink = livecodesStory({ config: { disableHomeLink: true } });
 export const ConfigJsonURL = livecodesStory({
   config:
     'https://raw.githubusercontent.com/hatemhosny/typescript-demo-for-testing-import-/gh-pages/src/livecodes.json',

--- a/storybook/web-components/stories/EmbedOptions/config.stories.ts
+++ b/storybook/web-components/stories/EmbedOptions/config.stories.ts
@@ -101,6 +101,7 @@ export const ModeResultCompiledOpen = livecodesStory({
   template: 'javascript',
   config: { mode: 'result', tools: { enabled: 'all', active: 'compiled', status: 'open' } },
 });
+export const disableHomeLink = livecodesStory({ config: { disableHomeLink: true } });
 export const ConfigJsonURL = livecodesStory({
   config:
     'https://raw.githubusercontent.com/hatemhosny/typescript-demo-for-testing-import-/gh-pages/src/livecodes.json',


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the LiveCodes Contributing Guide: https://github.com/live-codes/livecodes/blob/HEAD/CONTRIBUTING.md.
  - 📖 Read the LiveCodes Code of Conduct: https://github.com/live-codes/livecodes/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
  - 🌐 Use `window.deps.translateString` in .ts files and add `data-i18n` attributes in .html files to mark strings that needs to be translated.
-->

## What type of PR is this? (check all applicable)

- [x] ✨ Feature

## Description

A new config option `disableHomeLink` was added, which if set to `true` disables the link on LiveCodes logo ("Edit in LiveCodes") in embeds.

## Related Tickets & Documents

#985 #980 

## Added to documentations?

- [x] 📓 docs (./docs)
- [x] 📕 storybook (./storybook)
- [ ] 📜 README.md
- [ ] 🙅 no documentation needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `disableHomeLink` configuration option to disable the "Edit on LiveCodes" logo link in embedded playgrounds (defaults to `false`).

* **Documentation**
  * Added documentation for the new `disableHomeLink` configuration option.
  * Updated contribution documentation with additional setup and testing requirements for new configuration properties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/live-codes/livecodes/pull/986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->