### PR TITLE
enable/disable zoom button

### DIFF
--- a/docs/docs/configuration/configuration-object.mdx
+++ b/docs/docs/configuration/configuration-object.mdx
@@ -414,7 +414,7 @@ Sets the [display mode](../features/display-modes.mdx).
 
 ### `tools`
 
-Type: [`Partial<{ enabled: Array<'console' | 'compiled' | 'tests'> | 'all'; active: 'console' | 'compiled' | 'tests' | ''; status: 'closed' | 'open' | 'full' | 'none' | ''; }>`](../api/interfaces/Config.md#tools)
+Type: [`Partial<{ enabled: Array<'console' | 'compiled' | 'tests' | 'zoom'> | 'all'; active: 'console' | 'compiled' | 'tests' | ''; status: 'closed' | 'open' | 'full' | 'none' | ''; }>`](../api/interfaces/Config.md#tools)
 
 Default: `{ enabled: 'all', active: '', status: '' }`
 

--- a/src/livecodes/config/build-config.ts
+++ b/src/livecodes/config/build-config.ts
@@ -329,7 +329,9 @@ export const loadParamConfig = (config: Config, params: UrlQueryParams): Partial
         }
         paramsConfig.tools.enabled = paramsConfig.tools.enabled?.filter((t) => t !== tool) || [];
         if (paramsConfig.tools.active === tool) {
-          paramsConfig.tools.active = paramsConfig.tools.enabled?.[0] || '';
+          paramsConfig.tools.active =
+            (paramsConfig.tools.enabled as Array<Exclude<Tool['name'], 'zoom'>> | undefined)?.[0] ||
+            '';
         }
       }
     });

--- a/src/livecodes/config/validate-config.ts
+++ b/src/livecodes/config/validate-config.ts
@@ -37,7 +37,7 @@ export const validateConfig = (config: Partial<Config>): Partial<Config> => {
   const themes: Array<Config['theme']> = ['light', 'dark'];
   const layout: Array<Config['layout']> = ['responsive', 'horizontal', 'vertical'];
   const editorModes: Array<Config['editorMode']> = ['vim', 'emacs'];
-  const tools: Array<Tool['name']> = ['console', 'compiled', 'tests', 'zoom'];
+  const tools: Array<Tool['name'] | 'zoom'> = ['console', 'compiled', 'tests', 'zoom'];
   const toolsPaneStatus: ToolsPaneStatus[] = ['', 'full', 'closed', 'open', 'none'];
   const editors: Array<Config['editor']> = ['monaco', 'codemirror', 'codejar', 'auto'];
   const editorIds: EditorId[] = ['markup', 'style', 'script'];

--- a/src/livecodes/config/validate-config.ts
+++ b/src/livecodes/config/validate-config.ts
@@ -37,7 +37,7 @@ export const validateConfig = (config: Partial<Config>): Partial<Config> => {
   const themes: Array<Config['theme']> = ['light', 'dark'];
   const layout: Array<Config['layout']> = ['responsive', 'horizontal', 'vertical'];
   const editorModes: Array<Config['editorMode']> = ['vim', 'emacs'];
-  const tools: Array<Tool['name']> = ['console', 'compiled', 'tests'];
+  const tools: Array<Tool['name']> = ['console', 'compiled', 'tests', 'zoom'];
   const toolsPaneStatus: ToolsPaneStatus[] = ['', 'full', 'closed', 'open', 'none'];
   const editors: Array<Config['editor']> = ['monaco', 'codemirror', 'codejar', 'auto'];
   const editorIds: EditorId[] = ['markup', 'style', 'script'];
@@ -96,8 +96,11 @@ export const validateConfig = (config: Partial<Config>): Partial<Config> => {
         }),
     ...(x &&
     x.active != null &&
-    includes(tools, x.active) &&
-    (typeof x.enabled === 'string' ||
+    includes(
+      tools.filter((t) => t !== 'zoom'),
+      x.active,
+    ) &&
+    (x.enabled === 'all' ||
       x.enabled == null ||
       (Array.isArray(x.enabled) && includes(x.enabled, x.active)))
       ? { active: x.active }

--- a/src/livecodes/core.ts
+++ b/src/livecodes/core.ts
@@ -4823,6 +4823,14 @@ const configureToolsPane = (
     toolsPane.hide();
     return;
   }
+  const zoomBtn = UI.getZoomButton();
+  if (zoomBtn) {
+    if (tools?.enabled?.includes('zoom') || tools?.enabled === 'all') {
+      zoomBtn.classList.remove('hidden');
+    } else {
+      zoomBtn.classList.add('hidden');
+    }
+  }
   if (tools?.active) {
     toolsPane.setActiveTool(tools.active);
   }
@@ -4830,7 +4838,7 @@ const configureToolsPane = (
     toolsPane.close();
     return;
   }
-  if (tools.status === 'none') {
+  if (tools.status === 'none' || tools.enabled?.length === 0) {
     toolsPane.hide();
     return;
   }
@@ -5079,8 +5087,8 @@ const configureSimpleMode = (config: Config) => {
   setConfig({
     ...config,
     tools: {
-      enabled: ['console'],
-      active: 'console',
+      enabled: Array.isArray(config.tools?.enabled) ? config.tools.enabled : ['console'],
+      active: config.tools?.active || 'console',
       status: config.tools?.status || 'closed',
     },
   });

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -418,7 +418,7 @@ export type TemplateName =
 /**
  * Tools in the tools pane.
  */
-export type ToolName = 'console' | 'compiled' | 'tests' | 'zoom';
+export type ToolName = 'console' | 'compiled' | 'tests';
 
 /**
  * Status of the tools pane.
@@ -1070,8 +1070,8 @@ export interface AppConfig {
    * ```
    */
   tools: Partial<{
-    enabled: ToolName[] | 'all';
-    active: Exclude<ToolName, 'zoom'> | '';
+    enabled: Array<ToolName | 'zoom'> | 'all';
+    active: ToolName | '';
     status: ToolsPaneStatus;
   }>;
 

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -418,7 +418,7 @@ export type TemplateName =
 /**
  * Tools in the tools pane.
  */
-export type ToolName = 'console' | 'compiled' | 'tests';
+export type ToolName = 'console' | 'compiled' | 'tests' | 'zoom';
 
 /**
  * Status of the tools pane.
@@ -1071,7 +1071,7 @@ export interface AppConfig {
    */
   tools: Partial<{
     enabled: ToolName[] | 'all';
-    active: ToolName | '';
+    active: Exclude<ToolName, 'zoom'> | '';
     status: ToolsPaneStatus;
   }>;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the configuration reference to include the `zoom` option in `tools.enabled`.
* **New Features**
  * Added support for enabling the `zoom` tool via configuration, including showing the zoom control when `zoom` is enabled (or when `all` is selected).
* **Bug Fixes**
  * Improved tools pane visibility rules: it now hides when no tools are enabled.
  * Refined configuration validation and simple-mode behavior to recognize `zoom` as enableable while enforcing consistent active-tool handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->