### PR TITLE
fix tailwindcss docs

### DIFF
--- a/docs/docs/languages/tailwindcss.mdx
+++ b/docs/docs/languages/tailwindcss.mdx
@@ -58,15 +58,15 @@ CSS Frameworks supported in LiveCodes (e.g. Tailwind CSS, [UnoCSS](./unocss.mdx)
 
 ### Tailwind CSS Plugins
 
-Tailwind CSS plugins can be imported in the [style editor](../features/projects.mdx#style-editor).
+Tailwind CSS [legacy JavaScript-based plugins](https://v3.tailwindcss.com/docs/plugins#official-plugins) can be imported using the [`@plugin` directive](https://tailwindcss.com/docs/functions-and-directives#plugin-directive) in the [style editor](../features/projects.mdx#style-editor).
 
 ```css
-@import "@tailwindcss/forms";
-@import "@tailwindcss/typography";
-@import "@tailwindcss/aspect-ratio";
-@import "@tailwindcss/line-clamp";
+@plugin "@tailwindcss/forms";
+@plugin "@tailwindcss/typography";
+@plugin "@tailwindcss/aspect-ratio";
+@plugin "@tailwindcss/line-clamp";
+@plugin "@tailwindcss/container-queries";
 ```
-
 
 ## Processor Info
 

--- a/docs/docs/languages/tailwindcss.mdx
+++ b/docs/docs/languages/tailwindcss.mdx
@@ -58,7 +58,7 @@ CSS Frameworks supported in LiveCodes (e.g. Tailwind CSS, [UnoCSS](./unocss.mdx)
 
 ### Tailwind CSS Plugins
 
-Tailwind CSS [legacy JavaScript-based plugins](https://v3.tailwindcss.com/docs/plugins#official-plugins) can be imported using the [`@plugin` directive](https://tailwindcss.com/docs/functions-and-directives#plugin-directive) in the [style editor](../features/projects.mdx#style-editor).
+Tailwind CSS [legacy JavaScript-based plugins](https://v3.tailwindcss.com/docs/plugins#official-plugins) can be loaded using the [`@plugin` directive](https://tailwindcss.com/docs/functions-and-directives#plugin-directive) in the [style editor](../features/projects.mdx#style-editor).
 
 ```css
 @plugin "@tailwindcss/forms";

--- a/docs/docs/languages/tailwindcss.mdx
+++ b/docs/docs/languages/tailwindcss.mdx
@@ -65,7 +65,6 @@ Tailwind CSS [legacy JavaScript-based plugins](https://v3.tailwindcss.com/docs/p
 @plugin "@tailwindcss/typography";
 @plugin "@tailwindcss/aspect-ratio";
 @plugin "@tailwindcss/line-clamp";
-@plugin "@tailwindcss/container-queries";
 ```
 
 ## Processor Info


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Tailwind CSS Plugins guide to recommend using the `@plugin` directive instead of `@import "`@tailwindcss/`..."` for legacy JavaScript-based plugins.
  * Revised the example to include `@plugin` entries for `@tailwindcss/forms`, `@tailwindcss/typography`, `@tailwindcss/aspect-ratio`, and `@tailwindcss/line-clamp`.
  * Refreshed the accompanying description to point to the relevant Tailwind plugin directive documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->