### PR TITLE
change size label position

### DIFF
--- a/src/livecodes/styles/app.scss
+++ b/src/livecodes/styles/app.scss
@@ -1387,16 +1387,16 @@ a.tools-pane-title {
   background-color: var(--size-label-background);
   border: 1px solid var(--size-label-border);
   border-radius: var(--rs);
+  bottom: calc(5px + var(--toolbar-height)) !important;
   color: var(--size-label-color);
   cursor: auto;
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--s12);
-  left: 5px !important;
   max-height: calc(100vh - var(--toolbar-height));
   opacity: 0;
   padding: 2px;
   position: absolute;
-  top: 5px !important;
+  right: 5px !important;
   transition: opacity 0.2s;
   white-space: nowrap;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the on-screen size label position so it now appears in the bottom-right corner of the output area, with spacing that accounts for the toolbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->