### PR TITLE
update embed docs

### DIFF
--- a/docs/docs/features/embeds.mdx
+++ b/docs/docs/features/embeds.mdx
@@ -60,7 +60,7 @@ createPlayground('#container', {
 
 ## Embed via URL
 
-LiveCodes playgrounds can be embedded in many websites and apps simply by pasting a LiveCodes link. This works on platforms that support [oEmbed](https://oembed.com/) (e.g. Notion and many others).
+LiveCodes playgrounds can be embedded in many websites and apps simply by pasting a LiveCodes link. This works on platforms that support [oEmbed](https://oembed.com/) (e.g. [Notion](https://www.notion.com/) and many others).
 
 To embed a playground in a supported platform, paste a LiveCodes URL (**short** [share URL](./share.mdx) or a URL with [query params](../configuration/query-params.mdx)). The platform will automatically resolve the embed.
 

--- a/docs/docs/features/embeds.mdx
+++ b/docs/docs/features/embeds.mdx
@@ -70,14 +70,29 @@ Watch a [video demo](https://x.com/hatem_hosny_/status/2075653559706624472/video
 
 LiveCodes is registered on the [oEmbed provider registry](https://oembed.com/providers.json). Auto-discovery is also supported via `<link>` meta tags, so any platform that supports oEmbed discovery can automatically embed LiveCodes playgrounds.
 
-### iframely
+### Iframely
 
-[iframely](https://iframely.com/) is a popular oEmbed proxy that many platforms use. LiveCodes is supported by iframely out of the box.
+[Iframely](https://iframely.com/) is a popular oEmbed proxy that many platforms use. LiveCodes is supported by Iframely out of the box.
+
+### Embedly
+
+[Embedly](https://embed.ly/) is a popular embed provider which supports embedding LiveCodes playgrounds.
+
+
+### Medium
+
+[Medium](https://medium.com/) supports embedding LiveCodes playgrounds (via [embedly](https://embedly.com/)), by pasting a LiveCodes URL on its own line in the editor.
 
 ### WordPress
 
 The official [LiveCodes Embed](https://wordpress.org/plugins/livecodes-embed/) plugin allows embedding playgrounds in [WordPress](https://wordpress.org/), by pasting a LiveCodes URL on its own line in the Block editor or the classic editor.
 It also adds **LiveCodes** to the block inserter.
+
+## Community Plugins
+
+### Obsidian
+
+The [Obsidian](https://obsidian.md/) plugin [Livecodes Playground](https://community.obsidian.md/plugins/livecodes-playground) (by [gapmiss](https://github.com/gapmiss)), allows embedding LiveCodes playgrounds in Obsidian.
 
 ## Avoid Breaking Changes
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Embed via URL” section intro to better connect it with the oEmbed explanation.
  * Expanded and reformatted the provider list, adding Iframely, Embedly, and Medium and improving naming consistency.
  * Added a “Community Plugins” section highlighting an Obsidian Livecodes Playground plugin for embedding LiveCodes playgrounds.
  * Reorganized the WordPress plugin information to improve readability and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->