### PR TITLE
add formatters

### DIFF
--- a/docs/docs/contribution/code-formatting-system.mdx
+++ b/docs/docs/contribution/code-formatting-system.mdx
@@ -327,7 +327,9 @@ The worker's `load` handler triggers loading for a set of languages without bloc
 const load = (languages: Language[]) => {
   languages.forEach((language) => {
     if (getParser(language) != null) {
-      loadParser(language);
+      loadParser(language).catch(() => {
+        console.warn('Failed to load formatter for: ' + language);
+      });
     } else if (getFormatter(language) != null) {
       loadFormatter(language).catch(() => {
         console.warn('Failed to load formatter for: ' + language);

--- a/docs/docs/contribution/code-formatting-system.mdx
+++ b/docs/docs/contribution/code-formatting-system.mdx
@@ -31,9 +31,24 @@ interface Formatter {
 }
 
 interface FormatFn {
-  (value: string, cursorOffset: number, formatterConfig: Partial<FormatterConfig>): 
-    Promise<{ formatted: string; cursorOffset: number }>;
+  (value: string, cursorOffset: number, formatterConfig?: Partial<FormatterConfig>): Promise<{
+    formatted: string;
+    cursorOffset?: number;
+  }>;
 }
+```
+
+`cursorOffset` in the result is optional:
+
+- Prettier formatters return it via `prettier.formatWithCursor`.
+- wasm-fmt formatters return only `{ formatted }`.
+- clang-format may return a negative offset (`-1`) when it cannot determine a position.
+
+Consumers must therefore treat a missing or negative offset as `0`. Both CodeMirror and CodeJar clamp identically:
+
+```typescript
+const newOffset =
+  newValue.cursorOffset != null && newValue.cursorOffset >= 0 ? newValue.cursorOffset : 0;
 ```
 
 ## Formatter Types
@@ -67,6 +82,24 @@ export const parserPlugins = {
 };
 ```
 
+`PrettierParser.pluginUrls` is optional. A parser whose plugin is self-registering can omit it entirely:
+
+```typescript
+prettier: {
+  name: 'custom',
+  // no pluginUrls
+}
+```
+
+For plugins that must be loaded lazily (e.g. because they only work in a worker context), `prettier` can also be a function that returns a parser synchronously or asynchronously. The function is called by the worker on first use:
+
+```typescript
+prettier: () => ({
+  name: 'custom',
+  plugins: [(self as any).customPlugin],
+})
+```
+
 ### 2. Custom Formatters
 
 Languages without Prettier support use custom formatters:
@@ -86,6 +119,40 @@ export const go: LanguageSpecs = {
     },
   },
   // ...
+};
+```
+
+The `factory` may also be `async` and return a `Promise<FormatFn>`. This is how the WebAssembly-based formatters load their runtime: they dynamically `import()` a module from a CDN, initialize it, then return the formatting function. Dynamic `import()` works inside the classic formatting worker and the URL is left untouched by the bundler.
+
+```typescript
+// lang-cpp.ts
+import { wasmFmtClangBaseUrl } from '../../vendors';
+
+export const cpp: LanguageSpecs = {
+  name: 'cpp',
+  formatter: {
+    factory: async () => {
+      const formatter = await import(wasmFmtClangBaseUrl + 'clang-format-web.js');
+      await formatter.default();
+      return async (code) => ({ formatted: await formatter.format(code, 'main.cpp', 'Google') });
+    },
+  },
+  // ...
+};
+```
+
+When two languages share the same formatter (e.g. `python` and `python-wasm`), export the formatter object from one spec and reuse it in the other instead of duplicating the factory:
+
+```typescript
+// lang-python-wasm.ts
+import { wasmFmtRuffBaseUrl } from '../../vendors';
+
+export const pythonFormatter: LanguageSpecs['formatter'] = {
+  factory: async () => {
+    const formatter = await import(wasmFmtRuffBaseUrl + 'ruff_fmt_web.js');
+    await formatter.default();
+    return async (code) => ({ formatted: await formatter.format(code, 'main.py') });
+  },
 };
 ```
 
@@ -172,24 +239,101 @@ Messages between main thread and worker:
 
 `format.worker.ts` runs in a dedicated Web Worker:
 
-### Loading Prettier
+### Loading Parsers and Formatters
+
+Parsers and custom formatters are cached as **promises**, so concurrent requests share a single load:
 
 ```typescript
+const parsers: { [key: string]: Promise<PrettierParser> } = {};
+const formatters: { [key: string]: Promise<FormatFn> } = {};
+
 const loadPrettier = () => {
   importScripts(prettierUrl);
 };
 
-const loadParser = (language: Language): PrettierParser | undefined => {
+const loadParser = async (language: Language): Promise<PrettierParser | undefined> => {
   if (!(self as any).prettier) {
     loadPrettier();
   }
-  
+  if (language in parsers) {
+    return parsers[language];
+  }
+
   const parser = getParser(language);
-  parser.pluginUrls.forEach((pluginUrl) => {
-    importScripts(pluginUrl);
+  if (!parser) return;
+
+  if (!(self as any).prettierPlugins) {
+    (self as any).prettierPlugins = {};
+  }
+
+  let parserPromise: Promise<PrettierParser> | undefined;
+
+  if (typeof parser === 'function') {
+    parserPromise = Promise.resolve(parser());
+  } else if (parser.pluginUrls && parser.pluginUrls.length > 0) {
+    parser.plugins = parser.pluginUrls
+      .map((pluginUrl) => {
+        if (plugins[pluginUrl]) return true;
+        try {
+          importScripts(pluginUrl);
+          plugins[pluginUrl] = true;
+          return true;
+        } catch (err) {
+          console.warn('Failed to load formatter for: ' + language);
+          return false;
+        }
+      })
+      .filter(Boolean);
+    parserPromise = Promise.resolve(parser);
+  }
+
+  if (!parserPromise) return;
+  parsers[language] = parserPromise;
+  try {
+    return await parsers[language];
+  } catch (error) {
+    delete parsers[language];
+    throw error;
+  }
+};
+```
+
+`loadParser` handles the three parser shapes (a static `PrettierParser`, a parser factory function, or a parser with no `pluginUrls`) and skips plugins that were already loaded via `importScripts`. `loadFormatter` invokes the language's `factory`:
+
+```typescript
+const loadFormatter = async (language: Language): Promise<FormatFn | undefined> => {
+  if (language in formatters) {
+    return formatters[language];
+  }
+
+  const formatter = getFormatter(language);
+  if (!formatter || !('factory' in formatter)) return;
+
+  formatters[language] = Promise.resolve(formatter.factory(baseUrl, language));
+  try {
+    return await formatters[language];
+  } catch (error) {
+    delete formatters[language];
+    throw error;
+  }
+};
+```
+
+The promise is stored **before** the first `await`, so when an idle preload races a `format` request the `factory` runs only once. On failure the cache entry is deleted so a later retry re-runs the factory.
+
+The worker's `load` handler triggers loading for a set of languages without blocking; failures are logged and left to retry:
+
+```typescript
+const load = (languages: Language[]) => {
+  languages.forEach((language) => {
+    if (getParser(language) != null) {
+      loadParser(language);
+    } else if (getFormatter(language) != null) {
+      loadFormatter(language).catch(() => {
+        console.warn('Failed to load formatter for: ' + language);
+      });
+    }
   });
-  
-  return parser;
 };
 ```
 
@@ -204,7 +348,7 @@ const format = async (
 ) => {
   if (getParser(language) != null) {
     // Prettier-based formatting
-    const parser = loadParser(language);
+    const parser = await loadParser(language);
     return (self as any).prettier.formatWithCursor(value, {
       parser: parser?.name,
       plugins: prettierPlugins,
@@ -212,16 +356,28 @@ const format = async (
       ...formatterConfig,
     });
   }
-  
+
   if (getFormatter(language) != null) {
     // Custom formatter
-    const formatFn = loadFormatter(language);
-    return formatFn(value, cursorOffset);
+    const formatFn = await loadFormatter(language);
+    return formatFn?.(value, cursorOffset);
   }
-  
+
   return { formatted: value, cursorOffset };
 };
 ```
+
+### Wasm-based Formatters
+
+Several languages format using WebAssembly-compiled formatters from the [`wasm-fmt`](https://github.com/wasm-fmt) project. Their base URLs live in `src/livecodes/vendors.ts`:
+
+| Vendor constant | Package | Used by |
+|-----------------|---------|---------|
+| `wasmFmtClangBaseUrl` | `@wasm-fmt/clang-format` | C++, C++ (Wasm), C# (Wasm), Java |
+| `wasmFmtRuffBaseUrl` | `@wasm-fmt/ruff_fmt` | Python, Python (Wasm) |
+| `wasmFmtZigBaseUrl` | `@wasm-fmt/zig_fmt` | Zig (Wasm) |
+
+Each factory follows the same contract: dynamically `import()` `<baseUrl><name>_web.js`, `await` its default export to initialize the WASM runtime, then return a function that delegates to the module's `format` method. clang-format takes a filename and a style (`'Google'` for C++/Java, `'Microsoft'` for C#), while `ruff_fmt` and `zig_fmt` take only the source (and a filename for Ruff). The `_web.js` init resolves its `.wasm` sibling relative to `import.meta.url` and fetches it with a graceful fallback when the MIME type is not `application/wasm`, so no extra wasm-path wiring is needed.
 
 ---
 
@@ -320,7 +476,9 @@ const format = async () => {
   const oldValue = getValue();
   const newValue = await formatter(oldValue, offset, getFormatterConfig());
   setValue(newValue.formatted, false);
-  view.dispatch({ selection: { anchor: newValue.cursorOffset } });
+  const newOffset =
+    newValue.cursorOffset != null && newValue.cursorOffset >= 0 ? newValue.cursorOffset : 0;
+  view.dispatch({ selection: { anchor: newOffset } });
 };
 
 // codejar.ts
@@ -331,7 +489,9 @@ const format = async () => {
   const oldValue = getValue();
   const newValue = await formatter(oldValue, offset, getFormatterConfig());
   setValue(newValue.formatted);
-  codejar?.restore({ start: newValue.cursorOffset, end: newValue.cursorOffset });
+  const newOffset =
+    newValue.cursorOffset != null && newValue.cursorOffset >= 0 ? newValue.cursorOffset : 0;
+  codejar?.restore({ start: newOffset, end: newOffset });
 };
 ```
 
@@ -339,7 +499,7 @@ const format = async () => {
 
 ## Language Spec Formatter Definition
 
-Two formats supported:
+A `LanguageSpecs.formatter` is either a Prettier parser or a custom factory:
 
 ### Prettier Parser
 
@@ -347,21 +507,46 @@ Two formats supported:
 formatter: {
   prettier: {
     name: 'typescript',           // Parser name
-    pluginUrls: [
+    pluginUrls: [                 // Optional (omit when the plugin self-registers)
       parserPlugins.typescript,   // Parser plugin
-      parserPlugins.estree,        // Additional plugins
+      parserPlugins.estree,       // Additional plugins
     ],
   },
 }
 ```
 
+`prettier` may instead be a function that returns a `PrettierParser` (or a promise for one), called lazily by the worker:
+
+```typescript
+formatter: {
+  prettier: () => ({
+    name: 'custom',
+    plugins: [(self as any).customPlugin],
+  }),
+}
+```
+
 ### Custom Formatter Factory
+
+The factory receives the app `baseUrl` and the `Language` and returns a `FormatFn` or a `Promise<FormatFn>`:
 
 ```typescript
 formatter: {
   factory: (baseUrl: string, language: Language) => async (code: string) => {
     // Custom formatting logic
     return { formatted: code, cursorOffset: 0 };
+  },
+}
+```
+
+A factory can also be `async` to load a runtime before returning the `FormatFn`:
+
+```typescript
+formatter: {
+  factory: async () => {
+    const formatter = await import(wasmFmtClangBaseUrl + 'clang-format-web.js');
+    await formatter.default();
+    return async (code: string) => ({ formatted: await formatter.format(code, 'main.cpp', 'Google') });
   },
 }
 ```
@@ -399,6 +584,19 @@ formatter: {
    }
    ```
 
+3. **Wasm-based custom formatter:**
+   Add a vendor base URL in `src/livecodes/vendors.ts` (with `getUrl`), then load the module dynamically and initialize it in an `async` factory:
+   ```typescript
+   formatter: {
+     factory: async () => {
+       const formatter = await import(wasmFmtYourBaseUrl + 'your-web.js');
+       await formatter.default();
+       return async (code) => ({ formatted: await formatter.format(code) });
+     },
+   }
+   ```
+   Add the third-party license to `vendor-licenses.md` and document the formatter on the language's `docs/docs/languages/<lang>.mdx` page.
+
 ---
 
 ## Performance Considerations
@@ -407,3 +605,4 @@ formatter: {
 - **Lazy Loading:** Formatter loaded only when needed
 - **Fake Formatter:** Skipped completely in readonly/codeblock modes
 - **Prettier Lazy Load:** Prettier loaded only when first format needed
+- **Promise Cache:** Parser and formatter loads are cached as promises; concurrent requests share a single load and a failed load is evicted so it can be retried

--- a/docs/docs/languages/cpp-wasm.mdx
+++ b/docs/docs/languages/cpp-wasm.mdx
@@ -58,7 +58,7 @@ This comment can be added in the [`hiddenContent` property of the editor](../con
 
 ## Code Formatting
 
-Not supported.
+Using [@wasm-fmt/clang-format](https://github.com/wasm-fmt/clang-format), applying [Google's C++ style guide](https://google.github.io/styleguide/cppguide.html).
 
 ## Starter Template
 

--- a/docs/docs/languages/cpp.mdx
+++ b/docs/docs/languages/cpp.mdx
@@ -44,7 +44,7 @@ JavaScript can interact with the C++ runtime using the `livecodes.cpp` global:
 
 ## Code Formatting
 
-Not supported.
+Using [@wasm-fmt/clang-format](https://github.com/wasm-fmt/clang-format), applying [Google's C++ style guide](https://google.github.io/styleguide/cppguide.html).
 
 ## Starter Template
 

--- a/docs/docs/languages/csharp-wasm.mdx
+++ b/docs/docs/languages/csharp-wasm.mdx
@@ -105,7 +105,7 @@ Blazor WebAssembly with .NET WebAssembly runtime.
 
 ## Code Formatting
 
-using [Prettier](https://prettier.io/)
+Using [@wasm-fmt/clang-format](https://github.com/wasm-fmt/clang-format), applying [Microsoft's style guide](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference).
 
 ## Live Reload
 

--- a/docs/docs/languages/java.mdx
+++ b/docs/docs/languages/java.mdx
@@ -103,7 +103,7 @@ Example:
 
 ## Code Formatting
 
-Using [Prettier](https://prettier.io) with the [Prettier Java plugin](https://github.com/jhipster/prettier-java).
+Using [@wasm-fmt/clang-format](https://github.com/wasm-fmt/clang-format), applying [Google's Java style guide](https://google.github.io/styleguide/javaguide.html).
 
 ## Live Reload
 

--- a/docs/docs/languages/python-wasm.mdx
+++ b/docs/docs/languages/python-wasm.mdx
@@ -105,7 +105,7 @@ Pyodide v0.29.0, running Python v3.13.2
 
 ## Code Formatting
 
-Not supported.
+Using [@wasm-fmt/ruff_fmt](https://github.com/wasm-fmt/ruff_fmt).
 
 ## Live Reload
 

--- a/docs/docs/languages/python.mdx
+++ b/docs/docs/languages/python.mdx
@@ -53,7 +53,7 @@ Brython v3.12.3, running Python v3.12
 
 ## Code Formatting
 
-Not supported.
+Using [@wasm-fmt/ruff_fmt](https://github.com/wasm-fmt/ruff_fmt).
 
 ## Example Usage
 

--- a/docs/docs/languages/zig-wasm.mdx
+++ b/docs/docs/languages/zig-wasm.mdx
@@ -88,7 +88,7 @@ Zig 0.14.0
 
 ## Code Formatting
 
-Code formatting is not currently available for Zig.
+Using [@wasm-fmt/zig_fmt](https://github.com/wasm-fmt/zig_fmt).
 
 ## Live Reload
 

--- a/src/livecodes/editor/codejar/codejar.ts
+++ b/src/livecodes/editor/codejar/codejar.ts
@@ -261,7 +261,8 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     const oldValue = getValue();
     const newValue = await formatter(oldValue, offset, getFormatterConfig());
     setValue(newValue.formatted);
-    const newOffset = newValue.cursorOffset ?? 0;
+    const newOffset =
+      newValue.cursorOffset != null && newValue.cursorOffset >= 0 ? newValue.cursorOffset : 0;
     codejar?.restore({ start: newOffset, end: newOffset });
   };
 

--- a/src/livecodes/editor/codejar/codejar.ts
+++ b/src/livecodes/editor/codejar/codejar.ts
@@ -261,7 +261,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     const oldValue = getValue();
     const newValue = await formatter(oldValue, offset, getFormatterConfig());
     setValue(newValue.formatted);
-    const newOffset = newValue.cursorOffset >= 0 ? newValue.cursorOffset : 0;
+    const newOffset = newValue.cursorOffset ?? 0;
     codejar?.restore({ start: newOffset, end: newOffset });
   };
 

--- a/src/livecodes/editor/codemirror/codemirror.ts
+++ b/src/livecodes/editor/codemirror/codemirror.ts
@@ -434,7 +434,8 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     const oldValue = getValue();
     const newValue = await formatter(oldValue, offset, getFormatterConfig());
     setValue(newValue.formatted, false);
-    const newOffset = newValue.cursorOffset ?? 0;
+    const newOffset =
+      newValue.cursorOffset != null && newValue.cursorOffset >= 0 ? newValue.cursorOffset : 0;
     view.dispatch({ selection: { anchor: newOffset } });
   };
 

--- a/src/livecodes/editor/codemirror/codemirror.ts
+++ b/src/livecodes/editor/codemirror/codemirror.ts
@@ -434,7 +434,7 @@ export const createEditor = async (options: EditorOptions): Promise<CodeEditor> 
     const oldValue = getValue();
     const newValue = await formatter(oldValue, offset, getFormatterConfig());
     setValue(newValue.formatted, false);
-    const newOffset = newValue.cursorOffset >= 0 ? newValue.cursorOffset : 0;
+    const newOffset = newValue.cursorOffset ?? 0;
     view.dispatch({ selection: { anchor: newOffset } });
   };
 

--- a/src/livecodes/formatter/format.worker.ts
+++ b/src/livecodes/formatter/format.worker.ts
@@ -11,7 +11,7 @@ declare const importScripts: (...args: string[]) => void;
 let baseUrl: string;
 const parsers: { [key: string]: PrettierParser } = {};
 const plugins: { [key: string]: any } = {};
-const formatters: { [key: string]: FormatFn } = {};
+const formatters: { [key: string]: Promise<FormatFn> } = {};
 
 const loadPrettier = () => {
   importScripts(prettierUrl);
@@ -34,18 +34,16 @@ const getFormatter = (language: Language) =>
   languages.find((lang) => lang.name === language)?.formatter;
 
 const load = (languages: Language[]) => {
-  try {
-    languages.forEach((language) => {
-      if (getParser(language) != null) {
-        loadParser(language);
-      } else if (getFormatter(language) != null) {
-        loadFormatter(language);
-      }
-    });
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.warn('Failed to load formatter');
-  }
+  languages.forEach((language) => {
+    if (getParser(language) != null) {
+      loadParser(language);
+    } else if (getFormatter(language) != null) {
+      loadFormatter(language).catch(() => {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to load formatter for: ' + language);
+      });
+    }
+  });
 };
 
 function loadParser(language: Language): PrettierParser | undefined {
@@ -97,8 +95,13 @@ const loadFormatter = async (language: Language): Promise<FormatFn | undefined> 
   const formatter = getFormatter(language);
   if (!formatter || !('factory' in formatter)) return;
 
-  formatters[language] = await formatter.factory(baseUrl, language);
-  return formatters[language];
+  formatters[language] = Promise.resolve(formatter.factory(baseUrl, language));
+  try {
+    return await formatters[language];
+  } catch (error) {
+    delete formatters[language];
+    throw error;
+  }
 };
 
 const format = async (

--- a/src/livecodes/formatter/format.worker.ts
+++ b/src/livecodes/formatter/format.worker.ts
@@ -89,7 +89,7 @@ function loadParser(language: Language): PrettierParser | undefined {
   return parser;
 }
 
-const loadFormatter = (language: Language): FormatFn | undefined => {
+const loadFormatter = async (language: Language): Promise<FormatFn | undefined> => {
   if (language in formatters) {
     return formatters[language];
   }
@@ -97,7 +97,7 @@ const loadFormatter = (language: Language): FormatFn | undefined => {
   const formatter = getFormatter(language);
   if (!formatter || !('factory' in formatter)) return;
 
-  formatters[language] = formatter.factory(baseUrl, language);
+  formatters[language] = await formatter.factory(baseUrl, language);
   return formatters[language];
 };
 
@@ -128,7 +128,7 @@ const format = async (
     );
   }
   if (getFormatter(language) != null) {
-    const formatFn = loadFormatter(language);
+    const formatFn = await loadFormatter(language);
     const result = await formatFn?.(value, cursorOffset);
     return result || unFormatted;
   }

--- a/src/livecodes/formatter/format.worker.ts
+++ b/src/livecodes/formatter/format.worker.ts
@@ -39,7 +39,10 @@ const getFormatter = (language: Language) =>
 const load = (languages: Language[]) => {
   languages.forEach((language) => {
     if (getParser(language) != null) {
-      loadParser(language);
+      loadParser(language).catch(() => {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to load formatter for: ' + language);
+      });
     } else if (getFormatter(language) != null) {
       loadFormatter(language).catch(() => {
         // eslint-disable-next-line no-console

--- a/src/livecodes/formatter/format.worker.ts
+++ b/src/livecodes/formatter/format.worker.ts
@@ -9,7 +9,7 @@ declare const prettierPlugins: { [key: string]: { parsers: any } };
 declare const importScripts: (...args: string[]) => void;
 
 let baseUrl: string;
-const parsers: { [key: string]: PrettierParser } = {};
+const parsers: { [key: string]: Promise<PrettierParser> } = {};
 const plugins: { [key: string]: any } = {};
 const formatters: { [key: string]: Promise<FormatFn> } = {};
 
@@ -17,12 +17,15 @@ const loadPrettier = () => {
   importScripts(prettierUrl);
 };
 
-const getParser = (language: Language): PrettierParser | undefined => {
+const getParser = (
+  language: Language,
+): PrettierParser | (() => PrettierParser | Promise<PrettierParser>) | undefined => {
   const formatter = languages.find((lang) => lang.name === language)?.formatter;
   if (!formatter || !('prettier' in formatter)) return;
   const parser = formatter.prettier;
   if (!parser) return;
-  if (parser.pluginUrls.find((url) => url.includes('babel'))) {
+  if (typeof parser === 'function') return parser;
+  if (parser.pluginUrls?.find((url) => url.includes('babel'))) {
     return {
       ...parser,
       pluginUrls: Array.from(new Set([...parser.pluginUrls, parserPlugins.estree])),
@@ -46,7 +49,7 @@ const load = (languages: Language[]) => {
   });
 };
 
-function loadParser(language: Language): PrettierParser | undefined {
+const loadParser = async (language: Language): Promise<PrettierParser | undefined> => {
   if (!(self as any).prettier) {
     loadPrettier();
   }
@@ -60,32 +63,38 @@ function loadParser(language: Language): PrettierParser | undefined {
   if (!(self as any).prettierPlugins) {
     (self as any).prettierPlugins = {};
   }
-  parser.plugins = parser.pluginUrls
-    .map((pluginUrl) => {
-      if (plugins[pluginUrl]) return true;
-      try {
-        importScripts(pluginUrl);
-        plugins[pluginUrl] = true;
-        if (!prettierPlugins.pug && (self as any).pluginPug) {
-          prettierPlugins.pug = (self as any).pluginPug;
-        }
-        if (!prettierPlugins.java && (self as any).pluginJava?.default) {
-          prettierPlugins.java = (self as any).pluginJava.default;
-        }
-        return true;
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn('Failed to load formatter for: ' + language);
-        return false;
-      }
-    })
-    .filter(Boolean);
 
-  if (parser.plugins.length > 0) {
-    parsers[language] = parser;
+  let parserPromise: Promise<PrettierParser> | undefined;
+
+  if (typeof parser === 'function') {
+    parserPromise = Promise.resolve(parser());
+  } else if (parser.pluginUrls && parser.pluginUrls.length > 0) {
+    parser.plugins = parser.pluginUrls
+      .map((pluginUrl) => {
+        if (plugins[pluginUrl]) return true;
+        try {
+          importScripts(pluginUrl);
+          plugins[pluginUrl] = true;
+          return true;
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn('Failed to load formatter for: ' + language);
+          return false;
+        }
+      })
+      .filter(Boolean);
+    parserPromise = Promise.resolve(parser);
   }
-  return parser;
-}
+
+  if (!parserPromise) return;
+  parsers[language] = parserPromise;
+  try {
+    return await parsers[language];
+  } catch (error) {
+    delete parsers[language];
+    throw error;
+  }
+};
 
 const loadFormatter = async (language: Language): Promise<FormatFn | undefined> => {
   if (language in formatters) {
@@ -113,7 +122,7 @@ const format = async (
   const unFormatted = { formatted: value, cursorOffset };
 
   if (getParser(language) != null) {
-    const parser = loadParser(language);
+    const parser = await loadParser(language);
     const options = {
       useTabs: formatterConfig.useTabs ?? defaultConfig.useTabs,
       tabWidth: formatterConfig.tabSize ?? defaultConfig.tabSize,

--- a/src/livecodes/formatter/models.ts
+++ b/src/livecodes/formatter/models.ts
@@ -54,7 +54,7 @@ export interface FormattedMessage {
     value: string;
     cursorOffset: number;
     formatted: string;
-    formattedCursorOffset: number;
+    formattedCursorOffset: number | undefined;
   };
 }
 

--- a/src/livecodes/languages/cpp-wasm/lang-cpp-wasm-script.ts
+++ b/src/livecodes/languages/cpp-wasm/lang-cpp-wasm-script.ts
@@ -51,6 +51,7 @@ window.CPP_READY.then(() => postMessage({ loaded: true }));
 };
 
 livecodes.cpp = livecodes.cpp || {};
+livecodes.cpp.ready = false;
 livecodes.cpp.run =
   livecodes.cpp.run ||
   ((input: string) =>

--- a/src/livecodes/languages/cpp-wasm/lang-cpp-wasm.ts
+++ b/src/livecodes/languages/cpp-wasm/lang-cpp-wasm.ts
@@ -1,9 +1,17 @@
 import type { LanguageSpecs } from '../../models';
+import { wasmFmtClangBaseUrl } from '../../vendors';
 
 export const cppWasm: LanguageSpecs = {
   name: 'cpp-wasm',
   title: 'C++ (Wasm)',
   longTitle: 'C/C++ (Wasm)',
+  formatter: {
+    factory: async () => {
+      const formatter = await import(wasmFmtClangBaseUrl + 'clang-format-web.js');
+      await formatter.default();
+      return async (code) => ({ formatted: await formatter.format(code, 'main.cpp', 'Google') });
+    },
+  },
   compiler: {
     factory: () => async (code) => code,
     scripts: ({ baseUrl }) => [baseUrl + '{{hash:lang-cpp-wasm-script.js}}'],
@@ -18,6 +26,7 @@ export const cppWasm: LanguageSpecs = {
     'clang.cpp',
     'clang',
     'cpp',
+    'cc',
     'c',
     'C',
     'cp',

--- a/src/livecodes/languages/cpp/lang-cpp.ts
+++ b/src/livecodes/languages/cpp/lang-cpp.ts
@@ -1,18 +1,30 @@
 import type { LanguageSpecs } from '../../models';
-import { codeMirrorBaseUrl, monacoLanguagesBaseUrl, vendorsBaseUrl } from '../../vendors';
+import {
+  codeMirrorBaseUrl,
+  monacoLanguagesBaseUrl,
+  vendorsBaseUrl,
+  wasmFmtClangBaseUrl,
+} from '../../vendors';
 
 export const cdnUrl = vendorsBaseUrl + 'jscpp/JSCPP.es5.min.js';
 
 export const cpp: LanguageSpecs = {
   name: 'cpp',
   title: 'C++',
+  formatter: {
+    factory: async () => {
+      const formatter = await import(wasmFmtClangBaseUrl + 'clang-format-web.js');
+      await formatter.default();
+      return async (code) => ({ formatted: await formatter.format(code, 'main.cpp', 'Google') });
+    },
+  },
   compiler: {
     factory: () => async (code) => code,
     scripts: ({ baseUrl }) => [cdnUrl, baseUrl + '{{hash:lang-cpp-script.js}}'],
     scriptType: 'text/cpp',
     compiledCodeLanguage: 'cpp',
   },
-  extensions: ['cpp', 'c', 'C', 'cp', 'cxx', 'c++', 'cppm', 'ixx', 'ii', 'hpp', 'h'],
+  extensions: ['cpp', 'cc', 'c', 'C', 'cp', 'cxx', 'c++', 'cppm', 'ixx', 'ii', 'hpp', 'h'],
   editor: 'script',
   editorSupport: {
     monaco: { languageSupport: monacoLanguagesBaseUrl + 'cpp.js' },

--- a/src/livecodes/languages/csharp-wasm/lang-csharp-wasm-script.ts
+++ b/src/livecodes/languages/csharp-wasm/lang-csharp-wasm-script.ts
@@ -8,6 +8,7 @@ declare global {
 }
 
 livecodes.csharp ??= {};
+livecodes.csharp.ready = false;
 
 const waitFor = (condition: () => boolean | Promise<boolean>, timeout = 30_000) =>
   new Promise<boolean>((resolve) => {

--- a/src/livecodes/languages/csharp-wasm/lang-csharp-wasm.ts
+++ b/src/livecodes/languages/csharp-wasm/lang-csharp-wasm.ts
@@ -1,15 +1,15 @@
 import { codemirrorLegacy } from '../../editor/codemirror/utils';
 import type { LanguageSpecs } from '../../models';
-import { codeMirrorBaseUrl, monacoLanguagesBaseUrl } from '../../vendors';
-import { parserPlugins } from '../prettier';
+import { codeMirrorBaseUrl, monacoLanguagesBaseUrl, wasmFmtClangBaseUrl } from '../../vendors';
 
 export const csharpWasm: LanguageSpecs = {
   name: 'csharp-wasm',
   title: 'C# (Wasm)',
   formatter: {
-    prettier: {
-      name: 'java',
-      pluginUrls: [parserPlugins.java],
+    factory: async () => {
+      const formatter = await import(wasmFmtClangBaseUrl + 'clang-format-web.js');
+      await formatter.default();
+      return async (code) => ({ formatted: await formatter.format(code, 'main.cs', 'Microsoft') });
     },
   },
   compiler: {
@@ -22,7 +22,7 @@ export const csharpWasm: LanguageSpecs = {
   extensions: ['cs', 'csharp', 'wasm.cs', 'cs-wasm'],
   editor: 'script',
   editorSupport: {
-    monaco: { languageSupport: monacoLanguagesBaseUrl + 'csharp.js' },
+    monaco: { languageSupport: monacoLanguagesBaseUrl + 'csharp.js', language: 'csharp' },
     codemirror: {
       languageSupport: async () =>
         codemirrorLegacy((await import(codeMirrorBaseUrl + 'codemirror-lang-clike.js')).csharp),

--- a/src/livecodes/languages/go-wasm/lang-go-wasm-script.ts
+++ b/src/livecodes/languages/go-wasm/lang-go-wasm-script.ts
@@ -107,6 +107,7 @@ const workerSrc = `
 `;
 
 livecodes.goWasm = livecodes.goWasm || {};
+livecodes.goWasm.ready = false;
 
 livecodes.goWasm.worker = livecodes.goWasm.worker || createWorkerFromContent(workerSrc);
 const worker: Worker = livecodes.goWasm.worker;

--- a/src/livecodes/languages/java/lang-java-script.ts
+++ b/src/livecodes/languages/java/lang-java-script.ts
@@ -188,6 +188,7 @@ const getWorkerSrc = () => `
 
 // Java API
 livecodes.java = livecodes.java || {};
+livecodes.java.ready = false;
 livecodes.java.run =
   livecodes.java.run ||
   ((input = '') =>

--- a/src/livecodes/languages/java/lang-java.ts
+++ b/src/livecodes/languages/java/lang-java.ts
@@ -1,14 +1,16 @@
 import type { LanguageSpecs } from '../../models';
-import { codeMirrorBaseUrl, monacoLanguagesBaseUrl } from '../../vendors';
-import { parserPlugins } from '../prettier';
+import { codeMirrorBaseUrl, monacoLanguagesBaseUrl, wasmFmtClangBaseUrl } from '../../vendors';
 
 export const java: LanguageSpecs = {
   name: 'java',
   title: 'Java',
   formatter: {
-    prettier: {
-      name: 'java',
-      pluginUrls: [parserPlugins.java],
+    factory: async () => {
+      const formatter = await import(wasmFmtClangBaseUrl + 'clang-format-web.js');
+      await formatter.default();
+      return async (code) => ({
+        formatted: await formatter.format(code, 'main.java', 'Google'),
+      });
     },
   },
   compiler: {

--- a/src/livecodes/languages/pug/lang-pug.ts
+++ b/src/livecodes/languages/pug/lang-pug.ts
@@ -4,16 +4,20 @@ import { vendorsBaseUrl } from '../../vendors';
 export const pug: LanguageSpecs = {
   name: 'pug',
   title: 'Pug',
-
-  // disable formatter, till @prettier/plugin-pug supports prettier v3
-  // (https://github.com/prettier/plugin-pug/pull/411)
+  // // disable formatter, till @prettier/plugin-pug supports prettier v3
+  // // (https://github.com/prettier/plugin-pug/pull/411)
   // formatter: {
-  //   prettier: {
-  //     name: 'pug',
-  //     pluginUrls: [parserPlugins.pug],
+  //   prettier: () => {
+  //     (self as any).importScripts(parserPlugins.pug);
+  //     if (!(self as any).prettierPlugins.pug && (self as any).pluginPug) {
+  //       (self as any).prettierPlugins.pug = (self as any).pluginPug;
+  //     }
+  //     return {
+  //       name: 'pug',
+  //       plugins: [(self as any).pluginPug],
+  //     };
   //   },
   // },
-
   compiler: {
     url: vendorsBaseUrl + 'pug/pug.min.js',
     factory: (_config, baseUrl) => {

--- a/src/livecodes/languages/python-wasm/lang-python-wasm.ts
+++ b/src/livecodes/languages/python-wasm/lang-python-wasm.ts
@@ -1,9 +1,19 @@
 import type { LanguageSpecs } from '../../models';
+import { wasmFmtRuffBaseUrl } from '../../vendors';
+
+export const pythonFormatter: LanguageSpecs['formatter'] = {
+  factory: async () => {
+    const formatter = await import(wasmFmtRuffBaseUrl + 'ruff_fmt_web.js');
+    await formatter.default();
+    return async (code) => ({ formatted: await formatter.format(code, 'main.py') });
+  },
+};
 
 export const pythonWasm: LanguageSpecs = {
   name: 'python-wasm',
   title: 'Py (Wasm)',
   longTitle: 'Python (Wasm)',
+  formatter: pythonFormatter,
   compiler: {
     factory: () => async (code) => code,
     scripts: ({ baseUrl }) => [baseUrl + '{{hash:lang-python-wasm-script.js}}'],

--- a/src/livecodes/languages/python/lang-python.ts
+++ b/src/livecodes/languages/python/lang-python.ts
@@ -1,6 +1,7 @@
 import type { LanguageSpecs } from '../../models';
 import { getLanguageCustomSettings } from '../../utils/utils';
 import { brythonBaseUrl, codeMirrorBaseUrl, monacoLanguagesBaseUrl } from '../../vendors';
+import { pythonFormatter } from '../python-wasm/lang-python-wasm';
 
 const brythonUrl = brythonBaseUrl + 'brython.min.js';
 const stdlibUrl = brythonBaseUrl + 'brython_stdlib.js';
@@ -8,6 +9,7 @@ const stdlibUrl = brythonBaseUrl + 'brython_stdlib.js';
 export const python: LanguageSpecs = {
   name: 'python',
   title: 'Python',
+  formatter: pythonFormatter,
   compiler: {
     factory: () => async (code) => code,
     scripts: ({ compiled, config }) => {

--- a/src/livecodes/languages/zig-wasm/lang-zig-wasm.ts
+++ b/src/livecodes/languages/zig-wasm/lang-zig-wasm.ts
@@ -1,10 +1,17 @@
 import { codemirrorLegacy } from '../../editor/codemirror/utils';
 import type { LanguageSpecs } from '../../models';
-import { codeMirrorBaseUrl, monacoLanguagesBaseUrl } from '../../vendors';
+import { codeMirrorBaseUrl, monacoLanguagesBaseUrl, wasmFmtZigBaseUrl } from '../../vendors';
 
 export const zigWasm: LanguageSpecs = {
   name: 'zig-wasm',
   title: 'Zig (Wasm)',
+  formatter: {
+    factory: async () => {
+      const formatter = await import(wasmFmtZigBaseUrl + 'zig_fmt_web.js');
+      await formatter.default();
+      return async (code) => ({ formatted: await formatter.format(code) });
+    },
+  },
   compiler: {
     factory: () => async (code) => code,
     scripts: ({ baseUrl }) => [baseUrl + '{{hash:lang-zig-wasm-script.js}}'],

--- a/src/livecodes/models.ts
+++ b/src/livecodes/models.ts
@@ -110,11 +110,11 @@ export type FormatFn = (
   value: string,
   cursorOffset: number,
   formatterConfig?: Partial<FormatterConfig>,
-) => Promise<{ formatted: string; cursorOffset: number }>;
+) => Promise<{ formatted: string; cursorOffset?: number }>;
 
 export type LanguageFormatter =
   | {
-      factory: (baseUrl: string, language: Language) => FormatFn;
+      factory: (baseUrl: string, language: Language) => FormatFn | Promise<FormatFn>;
     }
   | { prettier: PrettierParser };
 

--- a/src/livecodes/models.ts
+++ b/src/livecodes/models.ts
@@ -104,7 +104,7 @@ export type ParserName =
 export interface PrettierParser {
   name: ParserName;
   plugins?: any[];
-  pluginUrls: string[];
+  pluginUrls?: string[];
 }
 export type FormatFn = (
   value: string,
@@ -116,7 +116,7 @@ export type LanguageFormatter =
   | {
       factory: (baseUrl: string, language: Language) => FormatFn | Promise<FormatFn>;
     }
-  | { prettier: PrettierParser };
+  | { prettier: PrettierParser | (() => PrettierParser | Promise<PrettierParser>) };
 
 export interface CssPreset {
   id: CssPresetId;

--- a/src/livecodes/vendors.ts
+++ b/src/livecodes/vendors.ts
@@ -492,6 +492,7 @@ export const wabtjsUrl = /* @__PURE__ */ getUrl('wabt@1.0.35/index.js');
 
 export const wasiShimUrl = /* @__PURE__ */ getUrl('@bjorn3/browser_wasi_shim@0.3.0/dist/index.js');
 
+export const wasmFmtClangBaseUrl = /* @__PURE__ */ getUrl('@wasm-fmt/clang-format@23.1.0/');
 export const wasmFmtRuffBaseUrl = /* @__PURE__ */ getUrl('@wasm-fmt/ruff_fmt@0.15.20/');
 export const wasmFmtZigBaseUrl = /* @__PURE__ */ getUrl('@wasm-fmt/zig_fmt@0.16.0/');
 

--- a/src/livecodes/vendors.ts
+++ b/src/livecodes/vendors.ts
@@ -492,6 +492,7 @@ export const wabtjsUrl = /* @__PURE__ */ getUrl('wabt@1.0.35/index.js');
 
 export const wasiShimUrl = /* @__PURE__ */ getUrl('@bjorn3/browser_wasi_shim@0.3.0/dist/index.js');
 
+export const wasmFmtRuffBaseUrl = /* @__PURE__ */ getUrl('@wasm-fmt/ruff_fmt@0.15.20/');
 export const wasmFmtZigBaseUrl = /* @__PURE__ */ getUrl('@wasm-fmt/zig_fmt@0.16.0/');
 
 export const wasmoonUrl = /* @__PURE__ */ getUrl('wasmoon@1.16.0/dist/index.js');

--- a/src/livecodes/vendors.ts
+++ b/src/livecodes/vendors.ts
@@ -492,6 +492,8 @@ export const wabtjsUrl = /* @__PURE__ */ getUrl('wabt@1.0.35/index.js');
 
 export const wasiShimUrl = /* @__PURE__ */ getUrl('@bjorn3/browser_wasi_shim@0.3.0/dist/index.js');
 
+export const wasmFmtZigBaseUrl = /* @__PURE__ */ getUrl('@wasm-fmt/zig_fmt@0.16.0/');
+
 export const wasmoonUrl = /* @__PURE__ */ getUrl('wasmoon@1.16.0/dist/index.js');
 
 export const waveDromBaseUrl = /* @__PURE__ */ getUrl('wavedrom@3.2.0/');

--- a/src/sdk/models.ts
+++ b/src/sdk/models.ts
@@ -158,6 +158,7 @@ export type Language =
   | 'phpwasm'
   | 'wasm.php'
   | 'cpp'
+  | 'cc'
   | 'c'
   | 'C'
   | 'cp'

--- a/vendor-licenses.md
+++ b/vendor-licenses.md
@@ -312,6 +312,8 @@ wabt.js: [Apache-2.0 license](https://github.com/AssemblyScript/wabt.js/blob/182
 
 wacl: [BSD 3-Clause License](https://github.com/ecky-l/wacl/blob/9daacabb0102a9986f33263261350edfeebdd83b/LICENSE)
 
+@wasm-fmt/clang-format: [MIT License](https://github.com/wasm-fmt/clang-format/blob/6a84f2d980e5ff4145bd9178a49cd5146e48df78/LICENSE)
+
 @wasm-fmt/ruff_fmt: [MIT License](https://github.com/wasm-fmt/ruff_fmt/blob/6dc277e1be013159858c7de6b150063baa7214bb/LICENSE)
 
 @wasm-fmt/zig_fmt: [MIT License](https://github.com/wasm-fmt/zig_fmt/blob/d998e708899565d509b6875c52c236bc36c00ca8/LICENSE)

--- a/vendor-licenses.md
+++ b/vendor-licenses.md
@@ -312,6 +312,10 @@ wabt.js: [Apache-2.0 license](https://github.com/AssemblyScript/wabt.js/blob/182
 
 wacl: [BSD 3-Clause License](https://github.com/ecky-l/wacl/blob/9daacabb0102a9986f33263261350edfeebdd83b/LICENSE)
 
+@wasm-fmt/ruff_fmt: [MIT License](https://github.com/wasm-fmt/ruff_fmt/blob/6dc277e1be013159858c7de6b150063baa7214bb/LICENSE)
+
+@wasm-fmt/zig_fmt: [MIT License](https://github.com/wasm-fmt/zig_fmt/blob/d998e708899565d509b6875c52c236bc36c00ca8/LICENSE)
+
 wasm-refmt: [MIT License](https://github.com/xtuc/webassemblyjs/blob/45f733aa96476d74c8ac57598e13406a48a6fdc8/LICENSE)
 
 wasmoon: [MIT License](https://github.com/ceifa/wasmoon/blob/6785315ea1146f00aeb6bdb125bf92df0243d7b4/LICENSE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added code formatting for C++, C# (Wasm), Python, and Zig.
  - Added Google, Microsoft, and language-specific formatting styles where applicable.
  - Added `cc` as a C++ alias.
  - Improved formatter loading and editor language detection.

- **Bug Fixes**
  - Language runtime readiness indicators now start in a defined state.
  - Improved formatter retry behavior after loading failures.
  - Improved cursor positioning when formatted code omits or provides an invalid offset.

- **Documentation**
  - Updated formatting support details and third-party licensing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->